### PR TITLE
fix(quic): channel handler の正常 close (EOF) を ERROR から DEBUG に degrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [0.4.2] - 2026-05-14
+
+### 修正
+- QUIC channel handler の正常 close (EOF) を ERROR から DEBUG に degrade ([#30](https://github.com/chronista-club/unison/pull/30))
+  - 正常終端の `NetworkError::Protocol("Channel closed" | "Raw channel closed" | "Request cancelled: channel closed")` が ERROR ログされていた問題を解消
+  - fleetstage prod で 24h 5739 件の偽 ERROR ノイズを発生させていた base 要因を除去
+
+### 追加
+- `NetworkError::is_normal_close()` helper メソッド
+  - 3 種類の正常 channel 終端 (`recv` / `recv_raw` / `request`) を判定
+  - 文字列マッチで暫定実装 (将来 `NetworkError::ChannelEof` enum variant 化予定 — USN-5)
+- Channel lifecycle ログの対称化: open 側も `debug!` で記録 (close 側と対応)
+
+### 内部
+- 設計ヒアリングを Linear に集約 (USN-1〜5)
+- Hierophant Green 💚 KDL schema を `schemas/hierophant.kdl` に定義 (USN-3 Phase 1)
+- `unison-mcp-probe` crate を追加: Claude Code から Unison サーバを対話的につつく MCP tool 群 (USN-2)
+
+## [0.4.1] - 2026-04-25
+
+### 追加
+- QUIC が DNS hostname と IPv4 リテラルを受け付けるように拡張 ([#29](https://github.com/chronista-club/unison/pull/29))
+  - `parse_ipv6_address` → `resolve_socket_addr` (async, `tokio::net::lookup_host` ベース)
+  - URL scheme strip (`https://` / `http://` / `quic://`)
+  - 9 件の unit test 追加 (IPv4 / IPv6 / hostname / scheme / unresolvable)
+
+### 後方互換
+- 既存 `[ipv6]:port` / `::1` / `8080` / `localhost:port` 経路は全て維持 (additive)
+
+## [0.4.0] - 2026-04-19
+
+### 追加
+- Codec トレイト + buffa (protobuf) 統合
+  - `UnisonChannel<C: Codec>` で JSON / protobuf を差し替え可能に
+  - `JsonCodec` (`serde::Serialize` / `DeserializeOwned`) と `ProtoCodec` (`buffa::Message`) を提供
+
 ## [0.3.0] - 2026-02-20
 
 ### 追加

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/crates/unison-protocol/src/network/mod.rs
+++ b/crates/unison-protocol/src/network/mod.rs
@@ -49,6 +49,22 @@ pub enum NetworkError {
     UnsupportedTransport(String),
 }
 
+impl NetworkError {
+    /// この error が **正常な channel 終端** (= sender side 完了で drop) を表すか判定する。
+    ///
+    /// `UnisonChannel::recv()` / `recv_raw()` は tokio mpsc receiver が None を返した時
+    /// `Protocol("Channel closed" | "Raw channel closed")` を生成する。 これは sender 側が
+    /// request/response 完了後に正常 close した end-of-stream であり、 真の error ではない。
+    /// caller (= e.g. QUIC server の channel handler dispatcher) は log level を ERROR ではなく
+    /// debug / info に degrade することで noise を抑えられる。
+    pub fn is_normal_close(&self) -> bool {
+        matches!(
+            self,
+            NetworkError::Protocol(msg) if msg == "Channel closed" || msg == "Raw channel closed"
+        )
+    }
+}
+
 /// プロトコルメッセージラッパー
 #[derive(Debug, Clone, Serialize, Deserialize, Archive, RkyvSerialize, RkyvDeserialize)]
 #[archive(check_bytes)]
@@ -148,4 +164,44 @@ pub struct ProtocolError {
     pub code: i32,
     pub message: String,
     pub details: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `NetworkError::is_normal_close()` が `UnisonChannel::recv()` /
+    /// `recv_raw()` で生成される 2 種類の "Channel closed" を正常終端と判定し、
+    /// それ以外の Protocol error / 他 variant は real error 扱いするか確認。
+    #[test]
+    fn is_normal_close_recognizes_channel_eof() {
+        // recv() の end-of-stream
+        assert!(NetworkError::Protocol("Channel closed".to_string()).is_normal_close());
+        // recv_raw() の end-of-stream
+        assert!(NetworkError::Protocol("Raw channel closed".to_string()).is_normal_close());
+    }
+
+    #[test]
+    fn is_normal_close_rejects_other_errors() {
+        // 他 Protocol error は real failure
+        assert!(
+            !NetworkError::Protocol("Failed to send channel open: io".to_string())
+                .is_normal_close()
+        );
+        assert!(
+            !NetworkError::Protocol("Failed to parse identity: bad json".to_string())
+                .is_normal_close()
+        );
+        // 別 variant
+        assert!(!NetworkError::Connection("conn refused".to_string()).is_normal_close());
+        assert!(!NetworkError::Quic("transport".to_string()).is_normal_close());
+        assert!(!NetworkError::Timeout.is_normal_close());
+        assert!(!NetworkError::NotConnected.is_normal_close());
+        assert!(
+            !NetworkError::HandlerNotFound {
+                method: "x".to_string()
+            }
+            .is_normal_close()
+        );
+    }
 }

--- a/crates/unison-protocol/src/network/mod.rs
+++ b/crates/unison-protocol/src/network/mod.rs
@@ -52,15 +52,26 @@ pub enum NetworkError {
 impl NetworkError {
     /// この error が **正常な channel 終端** (= sender side 完了で drop) を表すか判定する。
     ///
-    /// `UnisonChannel::recv()` / `recv_raw()` は tokio mpsc receiver が None を返した時
-    /// `Protocol("Channel closed" | "Raw channel closed")` を生成する。 これは sender 側が
-    /// request/response 完了後に正常 close した end-of-stream であり、 真の error ではない。
-    /// caller (= e.g. QUIC server の channel handler dispatcher) は log level を ERROR ではなく
-    /// debug / info に degrade することで noise を抑えられる。
+    /// `UnisonChannel::recv()` / `recv_raw()` / `request()` は内部の sender / oneshot が
+    /// drop された時に 3 種類の Protocol error を生成する:
+    ///
+    /// - `"Channel closed"` — `recv()` で mpsc receiver が None を返した
+    /// - `"Raw channel closed"` — `recv_raw()` で raw mpsc receiver が None を返した
+    /// - `"Request cancelled: channel closed"` — `request()` 中に oneshot sender が drop した
+    ///
+    /// これらは sender 側が request/response 完了後に正常 close した end-of-stream であり、
+    /// 真の error ではない。 caller (= e.g. QUIC server の channel handler dispatcher) は
+    /// log level を ERROR ではなく debug / info に degrade することで noise を抑えられる。
+    ///
+    /// 文字列マッチで判定しているため、将来追加されるパターンも忘れずにここを更新すること。
+    /// (長期的には `NetworkError::ChannelEof` のような enum variant 化で型安全にすべき)
     pub fn is_normal_close(&self) -> bool {
         matches!(
             self,
-            NetworkError::Protocol(msg) if msg == "Channel closed" || msg == "Raw channel closed"
+            NetworkError::Protocol(msg)
+                if msg == "Channel closed"
+                || msg == "Raw channel closed"
+                || msg == "Request cancelled: channel closed"
         )
     }
 }
@@ -171,7 +182,7 @@ mod tests {
     use super::*;
 
     /// `NetworkError::is_normal_close()` が `UnisonChannel::recv()` /
-    /// `recv_raw()` で生成される 2 種類の "Channel closed" を正常終端と判定し、
+    /// `recv_raw()` / `request()` で生成される 3 種類の正常終端を判定し、
     /// それ以外の Protocol error / 他 variant は real error 扱いするか確認。
     #[test]
     fn is_normal_close_recognizes_channel_eof() {
@@ -179,6 +190,11 @@ mod tests {
         assert!(NetworkError::Protocol("Channel closed".to_string()).is_normal_close());
         // recv_raw() の end-of-stream
         assert!(NetworkError::Protocol("Raw channel closed".to_string()).is_normal_close());
+        // request() 中の oneshot sender drop
+        assert!(
+            NetworkError::Protocol("Request cancelled: channel closed".to_string())
+                .is_normal_close()
+        );
     }
 
     #[test]

--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -9,7 +9,7 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::{
     NetworkError, ProtocolFrame, ProtocolMessage, context::ConnectionContext,
@@ -759,10 +759,21 @@ async fn handle_connection(
                                         recv_stream,
                                     );
                                     if let Err(e) = handler(ctx, stream).await {
-                                        error!(
-                                            "Channel handler error for '{}': {}",
-                                            channel_name, e
-                                        );
+                                        // sender 側が request/response 完了後に正常 close した
+                                        // end-of-stream は real error ではないので debug level に
+                                        // degrade。 これにより毎 channel session の終端で発生する
+                                        // ERROR log noise (= journal で大半を占める) を抑制。
+                                        if e.is_normal_close() {
+                                            debug!(
+                                                "Channel '{}' closed normally (end of stream)",
+                                                channel_name
+                                            );
+                                        } else {
+                                            error!(
+                                                "Channel handler error for '{}': {}",
+                                                channel_name, e
+                                            );
+                                        }
                                     }
                                 } else {
                                     warn!("No channel handler for: {}", channel_name);

--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -750,6 +750,14 @@ async fn handle_connection(
                                 if let Some(handler) =
                                     server.get_channel_handler(&channel_name).await
                                 {
+                                    // channel lifecycle の "open" 側ログ。
+                                    // close 側 (= 下記の debug!) と対になり、 1 接続中の
+                                    // channel 開閉 trace が debug level で揃う。
+                                    // info level にしない理由: 1 接続で channel が頻繁に
+                                    // open/close される設計 (= 1 request/response = 1 channel)
+                                    // なので info noise になりがち。
+                                    debug!("Channel '{}' opened", channel_name);
+
                                     // チャネル用のUnisonStreamを作成（ストリームは生きたまま）
                                     let stream = UnisonStream::from_streams(
                                         request.id,


### PR DESCRIPTION
## Summary

`UnisonChannel::recv()` の正常 end-of-stream (= sender 側 drop) が `NetworkError::Protocol(\"Channel closed\")` で表現され、 QUIC server の channel handler dispatch で **無条件 ERROR log** されていた問題を fix。 fleetstage prod (= cp.fleetstage.cloud) で 24h 5739 件の log noise を生む base 要因。

## Root cause

`crates/unison-protocol/src/network/channel.rs:248-253`:

\`\`\`rust
pub async fn recv(&self) -> Result<ProtocolMessage, NetworkError> {
    let mut rx = self.event_rx.lock().await;
    rx.recv().await
        .ok_or_else(|| NetworkError::Protocol(\"Channel closed\".to_string()))
}
\`\`\`

tokio mpsc receiver が None を返した時 (= sender drop = 正常終端) Protocol error を生成。 これが上流の \`crates/unison-protocol/src/network/quic.rs:761-766\`:

\`\`\`rust
if let Err(e) = handler(ctx, stream).await {
    error!(\"Channel handler error for '{}': {}\", channel_name, e);
}
\`\`\`

で **無条件 ERROR**。 つまり正常 lifecycle (= 1 request/response 完了 → sender close) が ERROR level で記録される。

## Fix

1. \`NetworkError::is_normal_close()\` helper を追加 (mod.rs):
   \`\`\`rust
   pub fn is_normal_close(&self) -> bool {
       matches!(
           self,
           NetworkError::Protocol(msg) if msg == \"Channel closed\" || msg == \"Raw channel closed\"
       )
   }
   \`\`\`
2. quic.rs:761 の dispatch で normal close は \`debug!\` に degrade、 他 error は \`error!\` keep:
   \`\`\`rust
   if e.is_normal_close() {
       debug!(\"Channel '{}' closed normally (end of stream)\", channel_name);
   } else {
       error!(\"Channel handler error for '{}': {}\", channel_name, e);
   }
   \`\`\`

## Test coverage

- \`network::tests::is_normal_close_recognizes_channel_eof\` ── 2 normal close 文字列を正検出
- \`network::tests::is_normal_close_rejects_other_errors\` ── 他 Protocol error / 別 variant は real error 判定
- regression: 既存 90 test 全 pass

## Scope

- 2 file 変更 (mod.rs +50 / quic.rs +21 -5)
- API surface 増: \`NetworkError::is_normal_close()\` public method 1 個 (= 非破壊、 既存 caller 無影響)
- log line 文言維持 (= 解読時の text match 可)、 level だけ DEBUG に degrade
- \`Raw channel closed\` も同じ idiom で扱う (= recv_raw 系も同 fix)

## Discovery context

fleetstage prod (= cp.fleetstage.cloud) で deploy.execute timeout 調査中、 24h journalctl 集計で:
- \`Channel handler error for 'health': Channel closed\` = **5739 件**
- \`server\` = 6 件、 \`deploy\` = 3 件、 \`tenant\` = 1 件、 \`project\` = 1 件
- どれも heartbeat / probe / RPC が正常完了して channel close した瞬間に発生

functional 影響なし (= heartbeat 自体は機能、 5/5 updated continue) だが noise が diagnosis 妨害、 真の error が埋もれる risk。

## Verification path (downstream)

merge → \`fleetflow\` Cargo.toml で unison rev bump → \`fleetstage\` Cargo.toml で fleetflow rev bump → fleetflowd + fleet-agent rebuild + redeploy。 完了後 cp.fleetstage.cloud で:

- [x] \`cargo build -p unison\` clean (= confirmed local)
- [x] \`cargo clippy -p unison\` clean (= confirmed)
- [x] \`cargo test -p unison\` 90/90 pass (= confirmed)
- [ ] downstream cascade で fleetstage 反映後、 \`journalctl -u fleetflowd | grep \"Channel handler error.*Channel closed\"\` が空になる
- [ ] 真の error (= Connection error / Quic error / 他 Protocol error) は引き続き ERROR で出る

## Related

- fleetstage memory: \`mem_1Cb1uZvJh7eibuVeEQpf59\` (= CP-side diagnostic)、 \`mem_1Cb1sPErN3TDjQwBo4AaP5\` (= Forge Mode Friction Catalog Friction #1-6)
- fleetflow PR #177 (= heartbeat method dispatch fix) と pair で full log noise 解消、 #177 + 本 PR で base case complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)