### PR TITLE
chore: v0.5.0 — crate を unison から club-unison に rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [0.5.0] - 2026-05-15
+
+### 変更 (Breaking — Cargo.toml level only)
+- **crate を `unison` から `club-unison` に rename** (chronista-club 命名規則に統一)
+  - crates.io 上の名前: `unison` → **`club-unison`** (旧名は別人 RobertWHurst の config loader、名前衝突回避)
+  - lib name は `unison` で据置 — **ソースコードの `use unison::...` は変更不要**
+  - 下流 consumer は Cargo.toml の dep 行のみ更新:
+    ```toml
+    # 旧
+    unison = "0.4"
+    # 新
+    club-unison = "0.5"
+    # または alias 維持
+    unison = { package = "club-unison", version = "0.5" }
+    ```
+- workspace 内の `unison-agent` / `unison-mcp-probe` の `unison` dep は `package = "club-unison"` alias で `use unison::...` を据置
+
+### 内部
+- ディレクトリ名は据置 (`crates/unison-protocol/` 等)。package name のみ rename。
+- 命名規則の根拠: chronista-club ecosystem の crates.io 公開 crate は **`club-` prefix** で統一 (vs 内部ツール用 `cc-` prefix = ccwire / ccws)
+
+### Future (本リリースの blocker ではないが残課題)
+- `unison-kdl` も同様に `club-kdl` に rename 予定 (別 repo 作業)
+- `club-kdl` の crates.io 公開後、本 crate も `cargo publish` 可能になる (現状は git dep 依存のため publish 不可)
+
 ## [0.4.2] - 2026-05-14
 
 ### 修正

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 KDL スキーマベースの型安全な QUIC 通信フレームワーク。
 
-[![Crates.io](https://img.shields.io/crates/v/unison.svg)](https://crates.io/crates/unison)
+[![Crates.io](https://img.shields.io/crates/v/club-unison.svg)](https://crates.io/crates/club-unison)
 [![Build Status](https://github.com/chronista-club/unison/workflows/CI/badge.svg)](https://github.com/chronista-club/unison/actions)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ```toml
 [dependencies]
-unison = "^0.3"
+# crates.io 名は `club-unison` (chronista-club 命名規則)、import path は `use unison::...` のまま
+club-unison = { version = "^0.5", package = "club-unison" }
+# もしくは alias で旧来の使用感に
+# unison = { package = "club-unison", version = "^0.5" }
 tokio = { version = "1.40", features = ["full"] }
 ```
 
@@ -188,7 +191,7 @@ protocol "my-service" version="1.0.0" {
 
 | クレート | 説明 |
 |---------|------|
-| [`unison-protocol`](crates/unison-protocol) | コアライブラリ。crates.io では `unison` として公開。KDL スキーマ、QUIC、チャネル、パケット |
+| [`unison-protocol`](crates/unison-protocol) | コアライブラリ。crates.io では `club-unison` として公開、import 時の lib name は `unison` 据置。KDL スキーマ、QUIC、チャネル、パケット |
 | [`unison-agent`](crates/unison-agent) | [Claude Agent SDK](https://crates.io/crates/claude-agent-sdk) 統合。AgentClient、InteractiveClient、MCP ツール公開 |
 
 ### unison-agent の例

--- a/crates/unison-agent/Cargo.toml
+++ b/crates/unison-agent/Cargo.toml
@@ -13,8 +13,8 @@ rust-version.workspace = true
 claude-agent-sdk = "0.1.1"
 futures = "0.3"
 
-# Unison Protocol
-unison = { path = "../unison-protocol", version = "0.4.0" }
+# Unison Protocol (package rename: `club-unison`, alias to `unison` for import compatibility)
+unison = { package = "club-unison", path = "../unison-protocol", version = "0.5.0" }
 
 # Workspace dependencies
 tokio = { workspace = true }

--- a/crates/unison-mcp-probe/Cargo.toml
+++ b/crates/unison-mcp-probe/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 rmcp.workspace = true
 schemars.workspace = true
 
-# Unison client
-unison = { path = "../unison-protocol" }
+# Unison client (package rename: `club-unison`, but kept as `unison` for import compatibility)
+unison = { package = "club-unison", path = "../unison-protocol" }
 
 # Runtime
 tokio.workspace = true

--- a/crates/unison-protocol/Cargo.toml
+++ b/crates/unison-protocol/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "unison"
+name = "club-unison"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -19,6 +19,13 @@ exclude = [
     "tests/*"
 ]
 rust-version.workspace = true
+
+# lib name 据置: package を `club-unison` に rename しても、
+# `use unison::Channel` のような import path は変更不要 (Cargo の rename trick)。
+# 詳細: creo-memories `mem_1Cb2haX6ZicuCweEpxAvj4` (club- prefix 命名規則)
+[lib]
+name = "unison"
+path = "src/lib.rs"
 
 [dependencies]
 miette.workspace = true


### PR DESCRIPTION
## Summary

crates.io 上の `unison` は別人 (RobertWHurst, 2018-) の config loader が占有しており publish 不可能。**chronista-club ecosystem は `club-` prefix で統一**する命名規則を採用、本 crate を rename する。

## 変更内容

| 要素 | Before | After |
|------|--------|-------|
| crates.io package name | `unison` | **`club-unison`** |
| lib name (`use xxx::...`) | `unison` | **`unison` 据置** |
| directory | `crates/unison-protocol/` | **据置** |
| workspace version | 0.4.2 | **0.5.0** (rename = breaking minor bump) |

## 命名規則の方針 (確立)

- **`club-` prefix は crates.io package name のみ** に付与
- lib name / directory / module path は短い元の名前のまま (= `use unison::...` 維持)
- 内部ツール (`ccwire`, `ccws`) は **`cc-` prefix**、公開 crate は **`club-` prefix** で役割分離

## API 影響

- **ソースコード**: `use unison::...` は無変更
- **Cargo.toml**: 下流 consumer は dep 行のみ更新
  ```toml
  # 旧
  unison = "0.4"
  # 新
  club-unison = "0.5"
  # または alias
  unison = { package = "club-unison", version = "0.5" }
  ```

## crates.io publish (本 PR では実施しない)

依存 `unison-kdl` が git dep のため、本 PR merge 後も crates.io publish は不可。
順序:
1. unison-kdl repo を `club-kdl` に rename + crates.io publish (別 repo 作業)
2. 本 repo の workspace dep を `club-kdl` に切替
3. `club-unison` を crates.io publish (0.5.1 patch として)

## 検証

- `cargo build --workspace --all-targets` → clean
- `cargo test --tests --workspace -- --skip packet` → all pass
- `cargo package -p unison-mcp-probe` で **`path` strip + `version` 要求** の挙動を確認済 (`publish = false` の crate なので publish はしない)

## 関連

- 命名規則 memory: creo `mem_1Cb2haX6ZicuCweEpxAvj4`
- 下流影響: fleetflow / vp / fleetstage の Cargo.toml dep 行更新