### PR TITLE
chore: v0.6.0 — club-kdl 移行 + lib name full rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [0.6.0] - 2026-05-15
+
+### 変更 (Breaking)
+- **`club-kdl` への依存切替 + lib name 統一**
+  - workspace dep: `unison-kdl = { git = ... }` → **`club-kdl = "0.5"`** (crates.io から取得、git dep 廃止)
+  - `crates/unison-protocol/Cargo.toml` の `[lib].name`: `unison` → **`club_unison`** (full rename policy 採用)
+  - 全 `use unison::...` → **`use club_unison::...`** (40+ 箇所一括置換)
+  - 全 `use unison_kdl::...` → **`use club_kdl::...`** (2 箇所)
+- workspace 内 dep: `unison = { package = "club-unison", ... }` alias を廃止 → 直接 `club-unison = { path = "..." }` 参照に変更
+
+### 命名規則の確定 (full rename policy)
+
+v0.5.0 では「package name のみ rename、lib name は据置」だったが、v0.6.0 で **「lib name も full rename」** へ方針変更:
+
+| Layer | v0.5.0 (旧方針) | v0.6.0 (新方針) |
+|-------|----------------|----------------|
+| crates.io package | `club-unison` | `club-unison` |
+| lib name (`use`) | `unison` (据置) | **`club_unison`** (rename) |
+| directory | `crates/unison-protocol/` | (据置) |
+
+理由: `club-kdl` 側 (lib name `club_kdl` に full rename 採用) と整合性を取るため、本 crate も統一。
+
+### 内部
+- `deny.toml`: git source 許可リストから unison-kdl 削除 (crates.io 公開に移行)
+- README: dep 例 + 使用例を `club_unison` に更新
+
+### 下流影響
+
+下流 consumer (fleetflow / vp / fleetstage / 等):
+```toml
+# 旧
+club-unison = "0.5"   # use unison::...
+# 新 (v0.6.0)
+club-unison = "0.6"   # use club_unison::...
+```
+
+ソースコードの `use unison::...` も全て `use club_unison::...` に書き換え必須。
+
+### crates.io publish
+
+本リリースで初の crates.io 公開が可能になる (依存 `club-kdl` が crates.io 公開済みのため)。
+
 ## [0.5.0] - 2026-05-15
 
 ### 変更 (Breaking — Cargo.toml level only)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"
@@ -74,7 +74,7 @@ indexmap = "2.6"
 scc = "3"
 tempfile = "3.13"
 kdl = "6.3.4"
-unison-kdl = { git = "https://github.com/chronista-club/unison-kdl.git" }
+club-kdl = "0.5"
 
 # Dev dependencies
 pretty_assertions = "1.4"

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ KDL スキーマベースの型安全な QUIC 通信フレームワーク。
 
 ```toml
 [dependencies]
-# crates.io 名は `club-unison` (chronista-club 命名規則)、import path は `use unison::...` のまま
-club-unison = { version = "^0.5", package = "club-unison" }
-# もしくは alias で旧来の使用感に
-# unison = { package = "club-unison", version = "^0.5" }
+# crates.io package = `club-unison`、Rust crate identifier = `club_unison`
+club-unison = "^0.6"
 tokio = { version = "1.40", features = ["full"] }
+```
+
+```rust
+use club_unison::{ProtocolServer, NetworkError};
+use club_unison::network::UnisonChannel;
 ```
 
 ---
@@ -47,8 +50,8 @@ sequenceDiagram
 ## サーバーを書く
 
 ```rust
-use unison::{ProtocolServer, NetworkError};
-use unison::network::UnisonChannel;
+use club_unison::{ProtocolServer, NetworkError};
+use club_unison::network::UnisonChannel;
 use serde_json::json;
 
 #[tokio::main]
@@ -83,7 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## クライアントを書く
 
 ```rust
-use unison::ProtocolClient;
+use club_unison::ProtocolClient;
 use serde_json::json;
 
 #[tokio::main]
@@ -191,7 +194,7 @@ protocol "my-service" version="1.0.0" {
 
 | クレート | 説明 |
 |---------|------|
-| [`unison-protocol`](crates/unison-protocol) | コアライブラリ。crates.io では `club-unison` として公開、import 時の lib name は `unison` 据置。KDL スキーマ、QUIC、チャネル、パケット |
+| [`unison-protocol`](crates/unison-protocol) | コアライブラリ。crates.io では `club-unison` として公開、Rust crate identifier は `club_unison`。KDL スキーマ、QUIC、チャネル、パケット |
 | [`unison-agent`](crates/unison-agent) | [Claude Agent SDK](https://crates.io/crates/claude-agent-sdk) 統合。AgentClient、InteractiveClient、MCP ツール公開 |
 
 ### unison-agent の例

--- a/crates/unison-agent/Cargo.toml
+++ b/crates/unison-agent/Cargo.toml
@@ -13,8 +13,8 @@ rust-version.workspace = true
 claude-agent-sdk = "0.1.1"
 futures = "0.3"
 
-# Unison Protocol (package rename: `club-unison`, alias to `unison` for import compatibility)
-unison = { package = "club-unison", path = "../unison-protocol", version = "0.5.0" }
+# club-unison: crates.io package、lib identifier は `club_unison`
+club-unison = { path = "../unison-protocol", version = "0.6.0" }
 
 # Workspace dependencies
 tokio = { workspace = true }

--- a/crates/unison-agent/src/tools.rs
+++ b/crates/unison-agent/src/tools.rs
@@ -6,7 +6,7 @@
 use claude_agent_sdk::mcp::{SdkMcpServer, SdkMcpTool, ToolResult};
 use serde_json::{Value, json};
 use tracing::{debug, info};
-use unison::ProtocolClient;
+use club_unison::ProtocolClient;
 
 use crate::error::{AgentError, Result};
 

--- a/crates/unison-mcp-probe/Cargo.toml
+++ b/crates/unison-mcp-probe/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 rmcp.workspace = true
 schemars.workspace = true
 
-# Unison client (package rename: `club-unison`, but kept as `unison` for import compatibility)
-unison = { package = "club-unison", path = "../unison-protocol" }
+# club-unison: crates.io package、lib identifier は `club_unison`
+club-unison = { path = "../unison-protocol" }
 
 # Runtime
 tokio.workspace = true

--- a/crates/unison-mcp-probe/src/tools.rs
+++ b/crates/unison-mcp-probe/src/tools.rs
@@ -73,7 +73,7 @@ impl UnisonProbe {
         &self,
         Parameters(args): Parameters<PingArgs>,
     ) -> Result<CallToolResult, McpError> {
-        use unison::ProtocolClient;
+        use club_unison::ProtocolClient;
 
         let client = ProtocolClient::new_default()
             .map_err(|e| McpError::internal_error(format!("client init failed: {e}"), None))?;
@@ -92,7 +92,7 @@ impl UnisonProbe {
         &self,
         Parameters(args): Parameters<CallArgs>,
     ) -> Result<CallToolResult, McpError> {
-        use unison::ProtocolClient;
+        use club_unison::ProtocolClient;
 
         let client = ProtocolClient::new_default()
             .map_err(|e| McpError::internal_error(format!("client init failed: {e}"), None))?;

--- a/crates/unison-protocol/Cargo.toml
+++ b/crates/unison-protocol/Cargo.toml
@@ -20,11 +20,11 @@ exclude = [
 ]
 rust-version.workspace = true
 
-# lib name 据置: package を `club-unison` に rename しても、
-# `use unison::Channel` のような import path は変更不要 (Cargo の rename trick)。
-# 詳細: creo-memories `mem_1Cb2haX6ZicuCweEpxAvj4` (club- prefix 命名規則)
+# lib name も `club_unison` に統一 (full rename policy、v0.6.0 で確定):
+# crates.io package = `club-unison`、Rust crate identifier = `club_unison`。
+# 詳細: creo-memories `mem_1Cb2haX6ZicuCweEpxAvj4` + annotations
 [lib]
-name = "unison"
+name = "club_unison"
 path = "src/lib.rs"
 
 [dependencies]
@@ -79,7 +79,7 @@ indexmap.workspace = true
 scc.workspace = true
 tempfile.workspace = true
 kdl.workspace = true
-unison-kdl.workspace = true
+club-kdl.workspace = true
 
 [build-dependencies]
 buffa-build.workspace = true

--- a/crates/unison-protocol/benches/quic_performance.rs
+++ b/crates/unison-protocol/benches/quic_performance.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Runtime;
 use tokio::sync::Barrier;
-use unison::network::channel::UnisonChannel;
-use unison::network::{MessageType, quic::QuicClient};
-use unison::{ProtocolClient, ProtocolServer};
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::{MessageType, quic::QuicClient};
+use club_unison::{ProtocolClient, ProtocolServer};
 
 /// メッセージサイズのバリエーション
 const MESSAGE_SIZES: &[usize] = &[64, 256, 1024, 4096, 16384];

--- a/crates/unison-protocol/benches/throughput.rs
+++ b/crates/unison-protocol/benches/throughput.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::runtime::Runtime;
-use unison::network::channel::UnisonChannel;
-use unison::network::{MessageType, quic::QuicClient};
-use unison::{ProtocolClient, ProtocolServer};
+use club_unison::network::channel::UnisonChannel;
+use club_unison::network::{MessageType, quic::QuicClient};
+use club_unison::{ProtocolClient, ProtocolServer};
 
 /// バッチサイズのバリエーション
 const BATCH_SIZES: &[u64] = &[1, 10, 100, 1000];

--- a/crates/unison-protocol/src/lib.rs
+++ b/crates/unison-protocol/src/lib.rs
@@ -17,7 +17,7 @@
 //! # use anyhow::Result;
 //! # #[tokio::main]
 //! # async fn main() -> Result<()> {
-//! use unison::{UnisonProtocol, NetworkError};
+//! use club_unison::{UnisonProtocol, NetworkError};
 //!
 //! // プロトコルスキーマを読み込み
 //! let mut protocol = UnisonProtocol::new();

--- a/crates/unison-protocol/src/network/server.rs
+++ b/crates/unison-protocol/src/network/server.rs
@@ -56,7 +56,7 @@ impl ConnectionEventReceiver {
     /// # 例
     ///
     /// ```rust,no_run
-    /// # use unison::ProtocolServer;
+    /// # use club_unison::ProtocolServer;
     /// # async fn example(server: &ProtocolServer) {
     /// let mut rx = server.subscribe_connection_events();
     /// loop {
@@ -238,7 +238,7 @@ impl ProtocolServer {
     /// # 例
     ///
     /// ```rust,no_run
-    /// # use unison::ProtocolServer;
+    /// # use club_unison::ProtocolServer;
     /// # async fn example(server: &ProtocolServer) {
     /// let mut rx = server.subscribe_connection_events();
     ///

--- a/crates/unison-protocol/src/packet/mod.rs
+++ b/crates/unison-protocol/src/packet/mod.rs
@@ -12,7 +12,7 @@
 //! ## 使用例
 //!
 //! ```ignore
-//! use unison::packet::{UnisonPacket, StringPayload};
+//! use club_unison::packet::{UnisonPacket, StringPayload};
 //!
 //! // フレーム作成
 //! let payload = StringPayload::from_string("Hello, World!");

--- a/crates/unison-protocol/src/parser/mod.rs
+++ b/crates/unison-protocol/src/parser/mod.rs
@@ -39,7 +39,7 @@ impl SchemaParser {
     pub fn parse(&self, input: &str) -> Result<ParsedSchema> {
         // unison-kdlを使ってパース
         let schema: ParsedSchema =
-            unison_kdl::from_str(input).map_err(|e| anyhow::anyhow!("KDL parsing error: {}", e))?;
+            club_kdl::from_str(input).map_err(|e| anyhow::anyhow!("KDL parsing error: {}", e))?;
 
         Ok(schema)
     }

--- a/crates/unison-protocol/src/parser/schema.rs
+++ b/crates/unison-protocol/src/parser/schema.rs
@@ -1,6 +1,6 @@
 use super::TypeRegistry;
 use std::collections::HashMap;
-use unison_kdl::KdlDeserialize;
+use club_kdl::KdlDeserialize;
 
 /// Parsed schema representation
 #[derive(Debug, Default, Clone, KdlDeserialize)]

--- a/crates/unison-protocol/src/prelude.rs
+++ b/crates/unison-protocol/src/prelude.rs
@@ -6,7 +6,7 @@
 //! # 使用例
 //!
 //! ```rust
-//! use unison::prelude::*;
+//! use club_unison::prelude::*;
 //! ```
 
 // パーサー関連

--- a/crates/unison-protocol/tests/cgp_integration_test.rs
+++ b/crates/unison-protocol/tests/cgp_integration_test.rs
@@ -3,11 +3,11 @@
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use unison::context::{
+use club_unison::context::{
     CgpProtocolContext, Handler, HandlerRegistry, MessageHandler, ServiceRegistry, TransportLayer,
     UnisonContextBuilder,
 };
-use unison::network::{MessageType, NetworkError, ProtocolMessage};
+use club_unison::network::{MessageType, NetworkError, ProtocolMessage};
 
 // ========================================
 // モックTransportLayer実装
@@ -241,7 +241,7 @@ async fn test_message_handler() {
 
 #[tokio::test]
 async fn test_handler_registry() {
-    use unison::context::MessageDispatcher;
+    use club_unison::context::MessageDispatcher;
 
     let registry = HandlerRegistry::new();
 
@@ -286,7 +286,7 @@ async fn test_handler_registry() {
 
 #[tokio::test]
 async fn test_handler_not_found() {
-    use unison::context::MessageDispatcher;
+    use club_unison::context::MessageDispatcher;
 
     let registry = HandlerRegistry::new();
 

--- a/crates/unison-protocol/tests/common/mod.rs
+++ b/crates/unison-protocol/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use unison::network::{MessageType, ProtocolMessage};
+use club_unison::network::{MessageType, ProtocolMessage};
 
 /// テスト用の ProtocolMessage を生成
 #[allow(dead_code)]
@@ -24,8 +24,8 @@ pub fn make_event(method: &str, payload: serde_json::Value) -> ProtocolMessage {
 
 /// テスト用 ServerIdentity を構築
 #[allow(dead_code)]
-pub fn make_identity(name: &str, channels: &[&str]) -> unison::network::identity::ServerIdentity {
-    use unison::network::identity::*;
+pub fn make_identity(name: &str, channels: &[&str]) -> club_unison::network::identity::ServerIdentity {
+    use club_unison::network::identity::*;
     let mut identity = ServerIdentity::new(name, "0.1.0", "test");
     for ch in channels {
         identity.add_channel(ChannelInfo {

--- a/crates/unison-protocol/tests/quic_integration_test.rs
+++ b/crates/unison-protocol/tests/quic_integration_test.rs
@@ -12,9 +12,9 @@ use std::time::{Duration, Instant};
 use tokio::time::timeout;
 use tracing::{Level, info};
 
-use unison::network::MessageType;
-use unison::network::channel::UnisonChannel;
-use unison::{ProtocolClient, ProtocolServer, ServerHandle};
+use club_unison::network::MessageType;
+use club_unison::network::channel::UnisonChannel;
+use club_unison::{ProtocolClient, ProtocolServer, ServerHandle};
 
 /// テスト用のトレーシング初期化（複数テストで呼ばれても安全）
 fn init_tracing() {

--- a/crates/unison-protocol/tests/simple_quic_test.rs
+++ b/crates/unison-protocol/tests/simple_quic_test.rs
@@ -22,7 +22,7 @@ async fn test_simple_quic_functionality() -> Result<()> {
 }
 
 async fn test_quic_server_config() -> Result<()> {
-    use unison::network::quic::QuicServer;
+    use club_unison::network::quic::QuicServer;
 
     info!("🔧 Testing QUIC server configuration");
 
@@ -34,7 +34,7 @@ async fn test_quic_server_config() -> Result<()> {
 }
 
 async fn test_quic_client_config() -> Result<()> {
-    use unison::network::quic::QuicClient;
+    use club_unison::network::quic::QuicClient;
 
     info!("🔧 Testing QUIC client configuration");
 
@@ -46,7 +46,7 @@ async fn test_quic_client_config() -> Result<()> {
 }
 
 async fn test_certificate_loading() -> Result<()> {
-    use unison::network::quic::QuicServer;
+    use club_unison::network::quic::QuicServer;
 
     info!("🔐 Testing certificate loading");
 
@@ -70,7 +70,7 @@ async fn test_certificate_loading() -> Result<()> {
 async fn test_embedded_certificates_integration() -> Result<()> {
     info!("🔐 Testing embedded certificates integration");
 
-    use unison::network::quic::QuicServer;
+    use club_unison::network::quic::QuicServer;
 
     // Test embedded certificate loading
     let embedded_result = QuicServer::load_cert_embedded();
@@ -106,7 +106,7 @@ async fn test_embedded_certificates_integration() -> Result<()> {
 async fn test_quic_transport_settings() -> Result<()> {
     info!("⚙️ Testing QUIC transport settings");
 
-    use unison::network::quic::{QuicClient, QuicServer};
+    use club_unison::network::quic::{QuicClient, QuicServer};
 
     // Test server transport configuration
     let _server_config = QuicServer::configure_server().await?;
@@ -133,7 +133,7 @@ async fn test_build_time_certificate_generation() -> Result<()> {
         info!("✅ Build-time certificates found in assets/certs/");
 
         // Test loading from external files
-        use unison::network::quic::QuicServer;
+        use club_unison::network::quic::QuicServer;
         let file_result = QuicServer::load_cert_from_files(
             "assets/certs/cert.pem",
             "assets/certs/private_key.der",
@@ -163,7 +163,7 @@ async fn test_build_time_certificate_generation() -> Result<()> {
 async fn test_performance_optimizations() -> Result<()> {
     info!("⚡ Testing performance optimizations");
 
-    use unison::network::quic::{QuicClient, QuicServer};
+    use club_unison::network::quic::{QuicClient, QuicServer};
 
     // Test that configurations are optimized for real-time communication
     let _server_config = QuicServer::configure_server().await?;

--- a/crates/unison-protocol/tests/test_codegen_channel.rs
+++ b/crates/unison-protocol/tests/test_codegen_channel.rs
@@ -1,6 +1,6 @@
-use unison::codegen::CodeGenerator;
-use unison::parser::TypeRegistry;
-use unison::prelude::*;
+use club_unison::codegen::CodeGenerator;
+use club_unison::parser::TypeRegistry;
+use club_unison::prelude::*;
 
 #[test]
 fn test_channel_codegen() {

--- a/crates/unison-protocol/tests/test_creo_sync.rs
+++ b/crates/unison-protocol/tests/test_creo_sync.rs
@@ -1,6 +1,6 @@
-use unison::codegen::CodeGenerator;
-use unison::parser::TypeRegistry;
-use unison::prelude::*;
+use club_unison::codegen::CodeGenerator;
+use club_unison::parser::TypeRegistry;
+use club_unison::prelude::*;
 
 #[test]
 fn test_creo_sync_parse_and_generate() {

--- a/crates/unison-protocol/tests/test_e2e_channel.rs
+++ b/crates/unison-protocol/tests/test_e2e_channel.rs
@@ -2,9 +2,9 @@
 //!
 //! チャネル型の生成（UnisonChannel, ConnectionBuilder）を検証。
 
-use unison::codegen::CodeGenerator;
-use unison::parser::TypeRegistry;
-use unison::prelude::*;
+use club_unison::codegen::CodeGenerator;
+use club_unison::parser::TypeRegistry;
+use club_unison::prelude::*;
 
 #[test]
 fn test_e2e_connection_builder_generation() {

--- a/crates/unison-protocol/tests/test_identity.rs
+++ b/crates/unison-protocol/tests/test_identity.rs
@@ -1,4 +1,4 @@
-use unison::network::identity::*;
+use club_unison::network::identity::*;
 
 #[test]
 fn test_identity_serialization() {

--- a/crates/unison-protocol/tests/test_identity_quic.rs
+++ b/crates/unison-protocol/tests/test_identity_quic.rs
@@ -1,4 +1,4 @@
-use unison::network::identity::*;
+use club_unison::network::identity::*;
 
 #[tokio::test]
 async fn test_identity_channel_flow() {

--- a/crates/unison-protocol/tests/test_integ_codegen_pipeline.rs
+++ b/crates/unison-protocol/tests/test_integ_codegen_pipeline.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use unison::codegen::{CodeGenerator, RustGenerator};
-use unison::parser::{SchemaParser, TypeRegistry};
+use club_unison::codegen::{CodeGenerator, RustGenerator};
+use club_unison::parser::{SchemaParser, TypeRegistry};
 
 /// schemas/ping_pong.kdl を読み込み → parse → generate Rust → 構造検証
 #[test]

--- a/crates/unison-protocol/tests/test_integ_error_paths.rs
+++ b/crates/unison-protocol/tests/test_integ_error_paths.rs
@@ -1,13 +1,13 @@
 mod common;
 
 use bytes::Bytes;
-use unison::context::{HandlerRegistry, MessageDispatcher};
-use unison::network::{MessageType, NetworkError, ProtocolMessage};
-use unison::packet::config::{CompressionConfig, PacketConfig};
-use unison::packet::header::{PacketType, UnisonPacketHeader};
-use unison::packet::payload::RkyvPayload;
-use unison::packet::serialization::PacketSerializer;
-use unison::packet::{SerializationError, UnisonPacket};
+use club_unison::context::{HandlerRegistry, MessageDispatcher};
+use club_unison::network::{MessageType, NetworkError, ProtocolMessage};
+use club_unison::packet::config::{CompressionConfig, PacketConfig};
+use club_unison::packet::header::{PacketType, UnisonPacketHeader};
+use club_unison::packet::payload::RkyvPayload;
+use club_unison::packet::serialization::PacketSerializer;
+use club_unison::packet::{SerializationError, UnisonPacket};
 
 /// 56バイト未満のバイト列 → from_bytes がエラー
 #[test]

--- a/crates/unison-protocol/tests/test_integ_handler_dispatch.rs
+++ b/crates/unison-protocol/tests/test_integ_handler_dispatch.rs
@@ -1,9 +1,9 @@
 mod common;
 
 use serde_json::Value;
-use unison::context::handlers::{CompositeHandler, EchoHandler, PingHandler};
-use unison::context::{HandlerRegistry, MessageDispatcher};
-use unison::network::{MessageType, NetworkError, ProtocolMessage};
+use club_unison::context::handlers::{CompositeHandler, EchoHandler, PingHandler};
+use club_unison::context::{HandlerRegistry, MessageDispatcher};
+use club_unison::network::{MessageType, NetworkError, ProtocolMessage};
 
 /// PingHandler を登録 → ProtocolMessage で dispatch → "Pong: ..." レスポンス検証
 #[tokio::test]
@@ -68,7 +68,7 @@ async fn test_integ_unregistered_method_dispatch() {
 /// MessageHandler トレイト経由での dispatch
 #[tokio::test]
 async fn test_integ_message_handler_trait_dispatch() {
-    use unison::context::MessageHandler as MH;
+    use club_unison::context::MessageHandler as MH;
 
     let registry = HandlerRegistry::new();
     registry.register("echo", EchoHandler).await;

--- a/crates/unison-protocol/tests/test_integ_identity_flow.rs
+++ b/crates/unison-protocol/tests/test_integ_identity_flow.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use unison::network::MessageType;
-use unison::network::identity::*;
-use unison::packet::UnisonPacketHeader;
+use club_unison::network::MessageType;
+use club_unison::network::identity::*;
+use club_unison::packet::UnisonPacketHeader;
 
 #[test]
 fn test_integ_identity_to_protocol_message_round_trip() {
@@ -19,7 +19,7 @@ fn test_integ_identity_to_protocol_message_round_trip() {
 
 #[tokio::test]
 async fn test_integ_identity_build_and_frame() {
-    use unison::network::ProtocolServer;
+    use club_unison::network::ProtocolServer;
 
     let server = ProtocolServer::with_identity("test-srv", "1.0.0", "ns");
     server
@@ -89,7 +89,7 @@ fn test_integ_channel_update_variants_json() {
 
 #[tokio::test]
 async fn test_integ_connection_context_identity_flow() {
-    use unison::network::context::ConnectionContext;
+    use club_unison::network::context::ConnectionContext;
 
     let ctx = ConnectionContext::new();
     assert!(ctx.identity().await.is_none());

--- a/crates/unison-protocol/tests/test_integ_protocol_message.rs
+++ b/crates/unison-protocol/tests/test_integ_protocol_message.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use unison::network::{MessageType, ProtocolMessage};
-use unison::packet::UnisonPacket;
+use club_unison::network::{MessageType, ProtocolMessage};
+use club_unison::packet::UnisonPacket;
 
 /// Request型 ProtocolMessage の into_frame → to_bytes → from_bytes → from_frame 往復
 #[test]
@@ -213,7 +213,7 @@ fn test_integ_new_encoded() {
 /// decode_payload で JsonCodec 経由のデコード
 #[test]
 fn test_integ_decode_payload_json() {
-    use unison::codec::JsonCodec;
+    use club_unison::codec::JsonCodec;
 
     let original = serde_json::json!({"name": "test", "count": 42});
     let msg = ProtocolMessage::new_with_json(
@@ -232,8 +232,8 @@ fn test_integ_decode_payload_json() {
 #[test]
 fn test_integ_decode_payload_proto() {
     use buffa::Message;
-    use unison::codec::ProtoCodec;
-    use unison::codec::proto::creo_sync::Subscribe;
+    use club_unison::codec::ProtoCodec;
+    use club_unison::codec::proto::creo_sync::Subscribe;
 
     let subscribe = Subscribe {
         category: "design".into(),
@@ -257,8 +257,8 @@ fn test_integ_decode_payload_proto() {
 #[test]
 fn test_integ_proto_frame_roundtrip() {
     use buffa::Message;
-    use unison::codec::ProtoCodec;
-    use unison::codec::proto::creo_sync::Ack;
+    use club_unison::codec::ProtoCodec;
+    use club_unison::codec::proto::creo_sync::Ack;
 
     let ack = Ack {
         status: "ok".into(),
@@ -289,7 +289,7 @@ fn test_integ_proto_frame_roundtrip() {
 #[test]
 fn test_integ_payload_as_value_with_proto_bytes_fails() {
     use buffa::Message;
-    use unison::codec::proto::creo_sync::Subscribe;
+    use club_unison::codec::proto::creo_sync::Subscribe;
 
     let subscribe = Subscribe {
         category: "test".into(),
@@ -312,8 +312,8 @@ fn test_integ_payload_as_value_with_proto_bytes_fails() {
 /// JSON でエンコードした payload を ProtoCodec でデコードするとエラー（Codec 混用検出）
 #[test]
 fn test_integ_decode_payload_wrong_codec_json_to_proto() {
-    use unison::codec::ProtoCodec;
-    use unison::codec::proto::creo_sync::Subscribe;
+    use club_unison::codec::ProtoCodec;
+    use club_unison::codec::proto::creo_sync::Subscribe;
 
     let msg = ProtocolMessage::new_with_json(
         1,
@@ -332,8 +332,8 @@ fn test_integ_decode_payload_wrong_codec_json_to_proto() {
 #[test]
 fn test_integ_decode_payload_wrong_codec_proto_to_json() {
     use buffa::Message;
-    use unison::codec::JsonCodec;
-    use unison::codec::proto::creo_sync::Subscribe;
+    use club_unison::codec::JsonCodec;
+    use club_unison::codec::proto::creo_sync::Subscribe;
 
     let subscribe = Subscribe {
         category: "test".into(),
@@ -407,8 +407,8 @@ fn test_integ_new_with_json_encodes_valid_json() {
 #[test]
 fn test_integ_proto_large_payload_compression_roundtrip() {
     use buffa::Message;
-    use unison::codec::ProtoCodec;
-    use unison::codec::proto::creo_sync::MemoryEvent;
+    use club_unison::codec::ProtoCodec;
+    use club_unison::codec::proto::creo_sync::MemoryEvent;
 
     // 圧縮閾値 (2048B) を超える proto ペイロードを生成
     let msg = MemoryEvent {

--- a/crates/unison-protocol/tests/test_integ_server_handlers.rs
+++ b/crates/unison-protocol/tests/test_integ_server_handlers.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use unison::network::ProtocolServer;
+use club_unison::network::ProtocolServer;
 
 #[tokio::test]
 async fn test_integ_register_and_get_channel_handler() {

--- a/crates/unison-protocol/tests/test_kdl.rs
+++ b/crates/unison-protocol/tests/test_kdl.rs
@@ -1,4 +1,4 @@
-use unison::prelude::*;
+use club_unison::prelude::*;
 
 #[test]
 fn test_basic_kdl_parsing() {

--- a/crates/unison-protocol/tests/test_medium_quic_lifecycle.rs
+++ b/crates/unison-protocol/tests/test_medium_quic_lifecycle.rs
@@ -10,9 +10,9 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tracing::{Level, info};
 
-use unison::network::MessageType;
-use unison::network::channel::UnisonChannel;
-use unison::{ProtocolClient, ProtocolServer};
+use club_unison::network::MessageType;
+use club_unison::network::channel::UnisonChannel;
+use club_unison::{ProtocolClient, ProtocolServer};
 
 /// テスト用のトレーシング初期化（複数テストで呼ばれても安全）
 fn init_tracing() {

--- a/crates/unison-protocol/tests/test_proto_buffa.rs
+++ b/crates/unison-protocol/tests/test_proto_buffa.rs
@@ -4,7 +4,7 @@
 //! buffa::Message トレイト経由で正しく往復できることを検証する。
 
 use buffa::Message;
-use unison::codec::proto::creo_sync::*;
+use club_unison::codec::proto::creo_sync::*;
 
 #[test]
 fn test_subscribe_roundtrip() {

--- a/deny.toml
+++ b/deny.toml
@@ -192,9 +192,8 @@ skip-tree = [
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = [
-    "https://github.com/chronista-club/unison-kdl.git",
-]
+allow-git = []
+# club-kdl は crates.io 公開 (v0.5.0~) のため git source 不要
 
 [sources.allow-org]
 # github.com organizations to allow git sources for


### PR DESCRIPTION
## Summary

unison-kdl が `club-kdl` として crates.io 公開 (v0.5.0) されたのを受け、本 crate も:
1. 依存切替: `unison-kdl = { git = ... }` → `club-kdl = "0.5"` (crates.io)
2. lib name full rename: `unison` → `club_unison` (整合性確保)
3. 一括置換: `use unison::...` → `use club_unison::...` (40+ 箇所)

これで **crates.io publish blocker 解消**、本 crate も crates.io 初公開可能に。

## 命名規則の方針変更 (v0.6.0 で確定)

v0.5.0 では「package のみ rename、lib name 据置」だったが、club-kdl が lib name も full rename したため**対称性を取って本 crate も full rename**:

| Layer | v0.5.0 (旧) | v0.6.0 (新) |
|-------|------------|-------------|
| crates.io package | club-unison | club-unison |
| lib name (`use`) | `unison` 据置 | **`club_unison`** rename |
| directory | crates/unison-protocol/ | (据置) |

## 検証

- ✅ `cargo build --workspace --all-targets` clean
- ✅ `cargo test --tests --workspace -- --skip packet` all pass
- 残 warning 1 件は既存 dead code (rename 無関係)

## 下流影響

```toml
# 旧
club-unison = "0.5"   # use unison::...
# 新 (v0.6.0)
club-unison = "0.6"   # use club_unison::...
```

下流 (fleetflow / vp / fleetstage / 等) は dep 行 + ソースコードの `use unison::...` 一括書換えが必要。

## merge 後の次のステップ
1. tag v0.6.0 + GitHub Release
2. `cargo publish -p club-unison` (初の crates.io 公開!)
3. 下流リポジトリの一括更新

## 関連
- club-kdl release: https://github.com/chronista-club/club-kdl/releases/tag/v0.5.0
- 命名規則 memory: creo `mem_1Cb2haX6ZicuCweEpxAvj4` (+ 2 annotations)
- unison-kdl 側 work_log: `mem_1Cb2wTYHBx1xcGghME7q14`