### PR TITLE
feat: v0.8.0 — Builder API + examples + mcp-probe trust arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [0.8.0] - 2026-05-15
+
+### 追加
+- **`QuicServer::builder(server)`** / **`QuicClient::builder()`** — v0.8.0+ の推奨構築 API
+  - `QuicServerBuilder::cert_source(CertSource)` — server 側 cert を明示
+  - `QuicClientBuilder::trust_anchors(TrustAnchors)` — client 側 trust を明示
+  - 旧 `QuicServer::new()` / `QuicClient::new()` は backward compat 用に維持 (default = `dev_localhost` / `SkipVerification`)
+- **`examples/builder_api.rs`** — 4 ユースケース (dev quickstart / internal mesh / from file / public CA) の使用例
+
+### 変更
+- `QuicClient` 内部に `trust_anchors: TrustAnchors` フィールド追加、`connect` が builder で設定された値を使用
+- `QuicServer` 内部に `cert_source: CertSource` フィールド追加、`bind` が builder で設定された値を使用
+- `unison-mcp-probe`: `unison_ping` / `unison_call` tool に `trust` 引数追加 (`"skip"` (default) | `"system"`)
+  - builder API のリファレンス実装として機能
+
+### 内部
+- 既存 `connect()` / `bind()` は instance の `trust_anchors` / `cert_source` を読むので、builder 経由なら明示的、`new()` 経由なら従来 default で互換性維持
+- これにより `ProtocolClient::new_default()` / `QuicClient::new()` 利用者は無変更で v0.8.0 に上がれる
+
 ## [0.7.0] - 2026-05-15
 
 ### 追加 (新 TLS API)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/crates/unison-agent/Cargo.toml
+++ b/crates/unison-agent/Cargo.toml
@@ -14,7 +14,7 @@ claude-agent-sdk = "0.1.1"
 futures = "0.3"
 
 # club-unison: crates.io package、lib identifier は `club_unison`
-club-unison = { path = "../unison-protocol", version = "0.7.0" }
+club-unison = { path = "../unison-protocol", version = "0.8.0" }
 
 # Workspace dependencies
 tokio = { workspace = true }

--- a/crates/unison-mcp-probe/src/tools.rs
+++ b/crates/unison-mcp-probe/src/tools.rs
@@ -38,10 +38,39 @@ impl Default for UnisonProbe {
 // Tool input schemas
 // ---------------------------------------------------------------------------
 
+/// Trust mode selector for the probe (matches `club_unison::TrustAnchors`).
+///
+/// - `"skip"`: skip cert verification (dev only, against self-signed servers)
+/// - `"system"`: use OS/webpki-roots trust store (for public servers)
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum TrustMode {
+    Skip,
+    System,
+}
+
+impl Default for TrustMode {
+    fn default() -> Self {
+        Self::Skip
+    }
+}
+
+impl TrustMode {
+    fn to_anchors(&self) -> club_unison::network::TrustAnchors {
+        match self {
+            Self::Skip => club_unison::network::TrustAnchors::SkipVerification,
+            Self::System => club_unison::network::TrustAnchors::System,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct PingArgs {
     /// Unison サーバの URL (例: `quic://[::1]:7878`)
     pub endpoint: String,
+    /// Trust anchor mode (default: `skip` — dev self-signed 用)
+    #[serde(default)]
+    pub trust: TrustMode,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -54,6 +83,9 @@ pub struct CallArgs {
     pub method: String,
     /// 送信する JSON payload
     pub payload: serde_json::Value,
+    /// Trust anchor mode (default: `skip`)
+    #[serde(default)]
+    pub trust: TrustMode,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -74,16 +106,21 @@ impl UnisonProbe {
         Parameters(args): Parameters<PingArgs>,
     ) -> Result<CallToolResult, McpError> {
         use club_unison::ProtocolClient;
+        use club_unison::network::quic::QuicClient;
 
-        let client = ProtocolClient::new_default()
+        // v0.8.0 builder で trust anchor を明示
+        let quic = QuicClient::builder()
+            .trust_anchors(args.trust.to_anchors())
+            .build()
             .map_err(|e| McpError::internal_error(format!("client init failed: {e}"), None))?;
+        let client = ProtocolClient::new(quic);
 
         client
             .connect(&args.endpoint)
             .await
             .map_err(|e| McpError::internal_error(format!("connect failed: {e}"), None))?;
 
-        let msg = format!("✅ connected to {}", args.endpoint);
+        let msg = format!("✅ connected to {} (trust={:?})", args.endpoint, args.trust);
         Ok(CallToolResult::success(vec![Content::text(msg)]))
     }
 
@@ -93,9 +130,14 @@ impl UnisonProbe {
         Parameters(args): Parameters<CallArgs>,
     ) -> Result<CallToolResult, McpError> {
         use club_unison::ProtocolClient;
+        use club_unison::network::quic::QuicClient;
 
-        let client = ProtocolClient::new_default()
+        // v0.8.0 builder で trust anchor を明示
+        let quic = QuicClient::builder()
+            .trust_anchors(args.trust.to_anchors())
+            .build()
             .map_err(|e| McpError::internal_error(format!("client init failed: {e}"), None))?;
+        let client = ProtocolClient::new(quic);
 
         client
             .connect(&args.endpoint)

--- a/crates/unison-protocol/examples/builder_api.rs
+++ b/crates/unison-protocol/examples/builder_api.rs
@@ -1,0 +1,88 @@
+//! v0.8.0+ Builder API showcase
+//!
+//! `QuicServer::builder()` / `QuicClient::builder()` を使って **明示的に**
+//! cert source / trust anchors を指定する例。
+//!
+//! ```bash
+//! cargo run -p club-unison --example builder_api
+//! ```
+//!
+//! 4 つのユースケースを順に示します:
+//! 1. Dev quickstart   (loopback、SelfSigned + SkipVerification)
+//! 2. Internal mesh    (server↔server、自己署名 cert + pinned trust)
+//! 3. From file        (k8s secret / cert-manager 配置を想定)
+//! 4. Public (System)  (Let's Encrypt 等の公開 CA chain を信頼)
+
+use anyhow::Result;
+use std::sync::Arc;
+
+use club_unison::network::quic::{QuicClient, QuicServer};
+use club_unison::network::{CertSource, InternalMeshKeypair, ProtocolServer, TrustAnchors};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    println!("=== v0.8.0 Builder API ===\n");
+
+    // -----------------------------------------------------------------------
+    // 1. Dev quickstart — localhost only
+    // -----------------------------------------------------------------------
+    println!("[1] Dev quickstart (loopback)");
+    let _server_quickstart = QuicServer::builder(Arc::new(ProtocolServer::new()))
+        .cert_source(CertSource::dev_localhost())
+        .build();
+    let _client_quickstart = QuicClient::builder()
+        .trust_anchors(TrustAnchors::SkipVerification) // dev だけ、本番では使わない
+        .build()?;
+    println!("    server: CertSource::dev_localhost()");
+    println!("    client: TrustAnchors::SkipVerification\n");
+
+    // -----------------------------------------------------------------------
+    // 2. Internal mesh — server↔server with shared cert material
+    // -----------------------------------------------------------------------
+    println!("[2] Internal mesh (server↔server, pinned trust)");
+    let mesh = InternalMeshKeypair::generate([
+        "broker.local".into(),
+        "*.unison.svc.cluster.local".into(),
+    ])?;
+    let _server_mesh = QuicServer::builder(Arc::new(ProtocolServer::new()))
+        .cert_source(mesh.server_cert_source)
+        .build();
+    let _client_mesh = QuicClient::builder()
+        .trust_anchors(mesh.client_trust_anchors)
+        .build()?;
+    println!("    InternalMeshKeypair で server cert + client trust を pair 生成");
+    println!("    両端が同じ cert material に bind され、SkipVerification 不要\n");
+
+    // -----------------------------------------------------------------------
+    // 3. Production via filesystem (k8s secret mount)
+    // -----------------------------------------------------------------------
+    println!("[3] Production (from file)");
+    println!("    server: CertSource::FromFile {{ cert_path: '/etc/tls/tls.crt', ... }}");
+    println!("    client: TrustAnchors::System (or TrustAnchors::Custom(ca_chain))\n");
+    // 実ファイルが無いと build に失敗するので例示のみ:
+    // let server = QuicServer::builder(Arc::new(ProtocolServer::new()))
+    //     .cert_source(CertSource::FromFile {
+    //         cert_path: "/etc/tls/tls.crt".into(),
+    //         key_path: "/etc/tls/tls.key".into(),
+    //     })
+    //     .build();
+
+    // -----------------------------------------------------------------------
+    // 4. Public CA chain — connect to a public Unison gateway
+    // -----------------------------------------------------------------------
+    println!("[4] Public CA chain (system trust)");
+    let _client_public = QuicClient::builder()
+        .trust_anchors(TrustAnchors::System)
+        .build()?;
+    println!("    client: TrustAnchors::System (webpki-roots Mozilla bundle)\n");
+
+    println!("=== 全パターン configure OK ===");
+    Ok(())
+}

--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -216,9 +216,57 @@ pub struct QuicClient {
     identity_tx: Arc<Mutex<Option<oneshot::Sender<ProtocolMessage>>>>,
     /// レスポンス受信タスクのハンドルを管理
     response_tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    /// Trust anchors used when verifying the server's certificate during connect.
+    ///
+    /// v0.8.0: explicit per-instance trust selection. Defaults to
+    /// `TrustAnchors::SkipVerification` for backward compatibility with
+    /// `QuicClient::new()` callers (will be tightened in v0.9.0).
+    trust_anchors: super::trust::TrustAnchors,
+}
+
+/// Builder for [`QuicClient`] (v0.8.0+).
+///
+/// Use [`QuicClient::builder`] to construct.
+pub struct QuicClientBuilder {
+    trust_anchors: Option<super::trust::TrustAnchors>,
+}
+
+impl QuicClientBuilder {
+    /// Set the trust anchor source used to verify server certs on `connect`.
+    pub fn trust_anchors(mut self, trust: super::trust::TrustAnchors) -> Self {
+        self.trust_anchors = Some(trust);
+        self
+    }
+
+    /// Build the [`QuicClient`]. If `trust_anchors` is not set, defaults to
+    /// [`super::trust::TrustAnchors::SkipVerification`] for backward
+    /// compatibility — a `tracing::warn!` is emitted at connect time.
+    pub fn build(self) -> Result<QuicClient> {
+        let trust_anchors = self
+            .trust_anchors
+            .unwrap_or(super::trust::TrustAnchors::SkipVerification);
+        let (tx, rx) = mpsc::unbounded_channel();
+        Ok(QuicClient {
+            endpoint: Mutex::new(None),
+            connection: Arc::new(RwLock::new(None)),
+            rx: Arc::new(RwLock::new(Some(rx))),
+            tx,
+            identity_rx: Arc::new(Mutex::new(None)),
+            identity_tx: Arc::new(Mutex::new(None)),
+            response_tasks: Arc::new(Mutex::new(Vec::new())),
+            trust_anchors,
+        })
+    }
 }
 
 impl QuicClient {
+    /// Builder entry point (v0.8.0+) — preferred over [`Self::new`].
+    pub fn builder() -> QuicClientBuilder {
+        QuicClientBuilder {
+            trust_anchors: None,
+        }
+    }
+
     pub fn new() -> Result<Self> {
         let (tx, rx) = mpsc::unbounded_channel();
         Ok(Self {
@@ -229,6 +277,7 @@ impl QuicClient {
             identity_rx: Arc::new(Mutex::new(None)),
             identity_tx: Arc::new(Mutex::new(None)),
             response_tasks: Arc::new(Mutex::new(Vec::new())),
+            trust_anchors: super::trust::TrustAnchors::SkipVerification,
         })
     }
 
@@ -320,10 +369,9 @@ impl QuicClient {
         // URL を解決 (IPv4 / IPv6 / DNS hostname)
         let addr = Self::parse_server_address(url).await?;
 
-        // 内部既定は SkipVerification (= 旧 configure_client() の挙動を維持)。
-        // 明示的な trust 選択は今後 ProtocolClient::builder() で行う。
-        let client_config =
-            Self::configure_client_with(super::trust::TrustAnchors::SkipVerification).await?;
+        // v0.8.0+: builder で設定された trust_anchors を使う (default = SkipVerification、
+        // builder 経由で TrustAnchors::System 等に明示変更可能)
+        let client_config = Self::configure_client_with(self.trust_anchors.clone()).await?;
 
         // bind addr は target family に揃える (IPv4 target には 0.0.0.0、IPv6 target には [::])
         let bind_addr: SocketAddr = match addr {
@@ -397,13 +445,56 @@ impl QuicClient {
 pub struct QuicServer {
     server: Arc<ProtocolServer>,
     endpoint: Option<Endpoint>,
+    /// Cert source used by `bind` to configure the TLS server.
+    ///
+    /// v0.8.0+: explicit per-instance cert selection via [`QuicServer::builder`].
+    /// Defaults to [`super::cert::CertSource::dev_localhost`] for backward
+    /// compatibility with `QuicServer::new()`.
+    cert_source: super::cert::CertSource,
+}
+
+/// Builder for [`QuicServer`] (v0.8.0+).
+///
+/// Use [`QuicServer::builder`] to construct.
+pub struct QuicServerBuilder {
+    server: Arc<ProtocolServer>,
+    cert_source: Option<super::cert::CertSource>,
+}
+
+impl QuicServerBuilder {
+    /// Set the cert source used to configure the TLS server at bind time.
+    pub fn cert_source(mut self, cert: super::cert::CertSource) -> Self {
+        self.cert_source = Some(cert);
+        self
+    }
+
+    /// Build the [`QuicServer`]. If `cert_source` is not set, defaults to
+    /// [`super::cert::CertSource::dev_localhost`] (DEV ONLY).
+    pub fn build(self) -> QuicServer {
+        QuicServer {
+            server: self.server,
+            endpoint: None,
+            cert_source: self
+                .cert_source
+                .unwrap_or_else(super::cert::CertSource::dev_localhost),
+        }
+    }
 }
 
 impl QuicServer {
+    /// Builder entry point (v0.8.0+) — preferred over [`Self::new`].
+    pub fn builder(server: Arc<ProtocolServer>) -> QuicServerBuilder {
+        QuicServerBuilder {
+            server,
+            cert_source: None,
+        }
+    }
+
     pub fn new(server: Arc<ProtocolServer>) -> Self {
         Self {
             server,
             endpoint: None,
+            cert_source: super::cert::CertSource::dev_localhost(),
         }
     }
 
@@ -496,11 +587,9 @@ impl QuicServer {
         // IPv4 / IPv6 / DNS hostname のいずれにも対応
         let socket_addr = Self::parse_socket_addr(addr).await?;
 
-        // 内部既定は dev_localhost (= 旧 configure_server() の挙動を維持、ただし
-        // assets/certs/ や rust-embed への fallback は廃止)。
-        // 明示的な cert 指定は今後 ProtocolServer::builder() で行う。
-        let server_config =
-            Self::configure_server_with(super::cert::CertSource::dev_localhost()).await?;
+        // v0.8.0+: builder で設定された cert_source を使う (default = dev_localhost、
+        // builder 経由で Provided / FromFile / internal_mesh に明示変更可能)
+        let server_config = Self::configure_server_with(self.cert_source.clone()).await?;
         let endpoint = Endpoint::server(server_config, socket_addr)?;
 
         info!("QUIC server bound to {}", socket_addr);


### PR DESCRIPTION
## Summary

v0.7.0 で導入した CertSource / TrustAnchors を **builder pattern で明示的に注入** できる API を追加。下流のリファレンス実装として examples + mcp-probe を更新。

## 新 API

```rust
// Server
let server = QuicServer::builder(Arc::new(ProtocolServer::new()))
    .cert_source(CertSource::dev_localhost())
    .build();

// Client
let client = QuicClient::builder()
    .trust_anchors(TrustAnchors::System)
    .build()?;
```

QuicClient/QuicServer に `trust_anchors` / `cert_source` field を持たせ、`connect()` / `bind()` がそれを参照する形に refactor。

## examples/builder_api.rs

4 ユースケース実例 (実行可能):
1. Dev quickstart (loopback)
2. Internal mesh (server↔server with InternalMeshKeypair)
3. From file (k8s secret mount)
4. Public CA chain (system trust)

```bash
cargo run -p club-unison --example builder_api
```

## unison-mcp-probe: trust 引数追加

\`unison_ping\` / \`unison_call\` tool に \`trust\` 引数 (\`\"skip\"\` (default) | \`\"system\"\`)。
builder API の使用例として下流の参考に。

## 後方互換

旧 \`QuicServer::new()\` / \`QuicClient::new()\` は維持、default は v0.7.0 と同じ
(\`dev_localhost\` / \`SkipVerification\`)。\`ProtocolClient::new_default()\` 利用者は無変更で OK。

## 検証

- \`cargo build --workspace --all-targets\` → clean
- \`cargo test --tests --workspace -- --skip packet\` → 全 pass
- \`cargo run --example builder_api\` → 4 ユースケース全 configure OK