### PR TITLE
fix(readme): v0.8.1 — crates.io 上で壊れる relative link を絶対 URL 化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティックバージョニング](https://semver.org/lang/ja/) に準拠しています。
 
+## [0.8.1] - 2026-05-15
+
+### 修正
+- **README の relative link を絶対 URL 化** — crates.io 上で render される際に repo 内の他ファイル/ディレクトリへの相対参照が壊れる問題を解消
+  - `CHANGELOG.md` / `LICENSE` / `crates/unison-protocol` / `crates/unison-agent` / `spec/01-core-concept/SPEC.md` / `spec/02-unified-channel/SPEC.md` / `guides/channel-guide.md` の 7 link を `https://github.com/chronista-club/unison/...` に書き換え
+- API・実装の変更なし、README のみの patch
+
 ## [0.8.0] - 2026-05-15
 
 ### 追加

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ let pair = InternalMeshKeypair::generate(["broker.local".into(), "*.unison.local
 // pair.client_trust_anchors → client 側
 ```
 
-詳細な trust model 設計は [CHANGELOG](CHANGELOG.md) の v0.7.0 entry 参照。
+詳細な trust model 設計は [CHANGELOG](https://github.com/chronista-club/unison/blob/main/CHANGELOG.md) の v0.7.0 entry 参照。
 
 ---
 
@@ -208,8 +208,8 @@ protocol "my-service" version="1.0.0" {
 
 | クレート | 説明 |
 |---------|------|
-| [`unison-protocol`](crates/unison-protocol) | コアライブラリ。crates.io では `club-unison` として公開、Rust crate identifier は `club_unison`。KDL スキーマ、QUIC、チャネル、パケット |
-| [`unison-agent`](crates/unison-agent) | [Claude Agent SDK](https://crates.io/crates/claude-agent-sdk) 統合。AgentClient、InteractiveClient、MCP ツール公開 |
+| [`unison-protocol`](https://github.com/chronista-club/unison/tree/main/crates/unison-protocol) | コアライブラリ。crates.io では `club-unison` として公開、Rust crate identifier は `club_unison`。KDL スキーマ、QUIC、チャネル、パケット |
+| [`unison-agent`](https://github.com/chronista-club/unison/tree/main/crates/unison-agent) | [Claude Agent SDK](https://crates.io/crates/claude-agent-sdk) 統合。AgentClient、InteractiveClient、MCP ツール公開 |
 
 ### unison-agent の例
 
@@ -235,13 +235,13 @@ IPv6 専用設計。アドレスは `[::1]:port` を使う。
 
 ## ドキュメント
 
-- [コアコンセプト](spec/01-core-concept/SPEC.md) — Everything is a Channel
-- [Unified Channel Protocol](spec/02-unified-channel/SPEC.md) — KDL スキーマ、コード生成
-- [チャネルガイド](guides/channel-guide.md) — 実践ガイド
+- [コアコンセプト](https://github.com/chronista-club/unison/blob/main/spec/01-core-concept/SPEC.md) — Everything is a Channel
+- [Unified Channel Protocol](https://github.com/chronista-club/unison/blob/main/spec/02-unified-channel/SPEC.md) — KDL スキーマ、コード生成
+- [チャネルガイド](https://github.com/chronista-club/unison/blob/main/guides/channel-guide.md) — 実践ガイド
 
 ## ライセンス
 
-MIT License - [LICENSE](LICENSE)
+MIT License - [LICENSE](https://github.com/chronista-club/unison/blob/main/LICENSE)
 
 ---
 

--- a/crates/unison-agent/Cargo.toml
+++ b/crates/unison-agent/Cargo.toml
@@ -14,7 +14,7 @@ claude-agent-sdk = "0.1.1"
 futures = "0.3"
 
 # club-unison: crates.io package、lib identifier は `club_unison`
-club-unison = { path = "../unison-protocol", version = "0.8.0" }
+club-unison = { path = "../unison-protocol", version = "0.8.1" }
 
 # Workspace dependencies
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

crates.io 上で published README を見たところ、repo 内の他ディレクトリ/ファイルへの relative link が **published crate に含まれず**、リンク切れになっていた。

7 link を `https://github.com/chronista-club/unison/...` 形式の absolute URL に書き換え。

| 旧 (relative) | 新 (absolute) |
|--------------|--------------|
| \`CHANGELOG.md\` | \`https://github.com/.../blob/main/CHANGELOG.md\` |
| \`LICENSE\` | \`https://github.com/.../blob/main/LICENSE\` |
| \`crates/unison-protocol\` | \`https://github.com/.../tree/main/crates/unison-protocol\` |
| \`crates/unison-agent\` | \`https://github.com/.../tree/main/crates/unison-agent\` |
| \`spec/01-core-concept/SPEC.md\` | \`https://github.com/.../blob/main/spec/...\` |
| \`spec/02-unified-channel/SPEC.md\` | 同上 |
| \`guides/channel-guide.md\` | 同上 |

## API 影響

なし、README only patch。