### PR TITLE
test(codegen): 現 generator 出力を回帰 baseline として凍結

### DIFF
--- a/crates/unison-protocol/tests/fixtures/codegen/creo_sync.rs.txt
+++ b/crates/unison-protocol/tests/fixtures/codegen/creo_sync.rs.txt
@@ -1,0 +1,110 @@
+use serde :: {
+    Deserialize ,
+    Serialize
+}; use anyhow :: Result; use chrono :: {
+    DateTime ,
+    Utc
+}; use uuid :: Uuid; use std :: collections :: HashMap; # [allow (unused_imports)] use crate :: network :: {
+    ProtocolClient ,
+    ProtocolServer
+}; # [allow (unused_imports)] use crate :: network :: channel :: UnisonChannel; # [allow (unused_imports)] use crate :: network :: datagram_channel :: DatagramChannel; # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Subscribe {
+    # [serde (skip_serializing_if = "Option::is_none")] pub category : Option < String > ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub tags : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Ack {
+    # [serde (skip_serializing_if = "Option::is_none")] pub status : Option < String > ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub channel_ref : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct MemoryEvent {
+    pub event_type : String ,
+    pub memory_id : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub category : Option < String > ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub from : Option < String > ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub timestamp : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Query {
+    pub method : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub params : Option < serde_json :: Value >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Result {
+    # [serde (skip_serializing_if = "Option::is_none")] pub data : Option < serde_json :: Value >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct QueryError {
+    # [serde (skip_serializing_if = "Option::is_none")] pub code : Option < String > ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub message : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct SendMessage {
+    pub from : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub to : Option < String > ,
+    pub content : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub thread : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct MessageAck {
+    # [serde (skip_serializing_if = "Option::is_none")] pub status : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct CCMessage {
+    pub from : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub to : Option < String > ,
+    pub content : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub thread : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Alert {
+    pub level : String ,
+    pub title : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub body : Option < String >
+} # [doc = r" インメモリチャネルベースのConnection（テスト用）"] pub struct CreoSyncConnection {
+    pub control : UnisonChannel ,
+    pub events : UnisonChannel ,
+    pub query : UnisonChannel ,
+    pub messaging : UnisonChannel ,
+    pub urgent : UnisonChannel
+} # [doc = r" QUICストリームベースのConnection（本番用）"] pub struct CreoSyncQuicConnection {
+    pub control : UnisonChannel ,
+    pub events : UnisonChannel ,
+    pub query : UnisonChannel ,
+    pub messaging : UnisonChannel ,
+    pub urgent : UnisonChannel
+} # [doc = r" ConnectionBuilderトレイト"] pub trait CreoSyncConnectionBuilder {
+    fn build (client : & crate :: network :: client :: ProtocolClient ,) -> impl std :: future :: Future < Output = Result < CreoSyncQuicConnection >> + Send;
+} impl CreoSyncConnectionBuilder for CreoSyncQuicConnection {
+    async fn build (client : & crate :: network :: client :: ProtocolClient ,) -> Result < CreoSyncQuicConnection > {
+    Ok (CreoSyncQuicConnection {
+    control : client . open_channel ("control") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "control" ,
+    e)) ? ,
+    events : client . open_channel ("events") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "events" ,
+    e)) ? ,
+    query : client . open_channel ("query") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "query" ,
+    e)) ? ,
+    messaging : client . open_channel ("messaging") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "messaging" ,
+    e)) ? ,
+    urgent : client . open_channel ("urgent") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "urgent" ,
+    e)) ?
+})
+}
+}

--- a/crates/unison-protocol/tests/fixtures/codegen/creo_sync.ts.txt
+++ b/crates/unison-protocol/tests/fixtures/codegen/creo_sync.ts.txt
@@ -1,0 +1,206 @@
+// Auto-generated TypeScript definitions
+// DO NOT EDIT MANUALLY
+
+export type Timestamp = string; // ISO-8601 format
+export type UUID = string;
+export type LanguageCode = string; // ISO 639-1 format
+
+// Namespace: club.chronista.sync
+// Version: 2.0.0
+
+// ════════════════════════════════════════════════
+// Channel: control (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Request "Subscribe" */
+export interface Subscribe {
+  category?: string;
+  tags?: string;
+}
+
+/** Response "Ack" */
+export interface Ack {
+  status?: string;
+  channel_ref?: string;
+}
+
+/** Event name → 生成 interface の map for "control" (= type-narrowing 用) */
+export type ControlChannelEventTypes = Record<string, never>;
+
+/** Request name → { request, response } 生成 interface の map for "control" */
+export interface ControlChannelRequestTypes {
+  Subscribe: { request: Subscribe; response: Ack };
+}
+
+/** Channel metadata for "control" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const ControlChannelMeta = {
+  name: "control" as const,
+  backend: "stream" as const,
+  from: "client" as const,
+  lifetime: "persistent" as const,
+  events: [] as const,
+  requests: {
+    Subscribe: { request: "Subscribe" as const, response: "Ack" as const },
+  } as const,
+  __types: undefined as unknown as { events: ControlChannelEventTypes; requests: ControlChannelRequestTypes },
+} as const;
+
+
+// ════════════════════════════════════════════════
+// Channel: events (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Event "MemoryEvent" */
+export interface MemoryEvent {
+  event_type: string;
+  memory_id: string;
+  category?: string;
+  from?: string;
+  timestamp?: string;
+}
+
+/** Event name → 生成 interface の map for "events" (= type-narrowing 用) */
+export interface EventsChannelEventTypes {
+  MemoryEvent: MemoryEvent;
+}
+
+/** Request name → { request, response } 生成 interface の map for "events" */
+export type EventsChannelRequestTypes = Record<string, never>;
+
+/** Channel metadata for "events" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const EventsChannelMeta = {
+  name: "events" as const,
+  backend: "stream" as const,
+  from: "server" as const,
+  lifetime: "persistent" as const,
+  events: ["MemoryEvent"] as const,
+  requests: {} as const,
+  __types: undefined as unknown as { events: EventsChannelEventTypes; requests: EventsChannelRequestTypes },
+} as const;
+
+
+// ════════════════════════════════════════════════
+// Channel: query (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Event "QueryError" */
+export interface QueryError {
+  code?: string;
+  message?: string;
+}
+
+/** Request "Query" */
+export interface Query {
+  method: string;
+  params?: any;
+}
+
+/** Response "Result" */
+export interface Result {
+  data?: any;
+}
+
+/** Event name → 生成 interface の map for "query" (= type-narrowing 用) */
+export interface QueryChannelEventTypes {
+  QueryError: QueryError;
+}
+
+/** Request name → { request, response } 生成 interface の map for "query" */
+export interface QueryChannelRequestTypes {
+  Query: { request: Query; response: Result };
+}
+
+/** Channel metadata for "query" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const QueryChannelMeta = {
+  name: "query" as const,
+  backend: "stream" as const,
+  from: "client" as const,
+  lifetime: "persistent" as const,
+  events: ["QueryError"] as const,
+  requests: {
+    Query: { request: "Query" as const, response: "Result" as const },
+  } as const,
+  __types: undefined as unknown as { events: QueryChannelEventTypes; requests: QueryChannelRequestTypes },
+} as const;
+
+
+// ════════════════════════════════════════════════
+// Channel: messaging (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Event "CCMessage" */
+export interface CCMessage {
+  from: string;
+  to?: string;
+  content: string;
+  thread?: string;
+}
+
+/** Request "SendMessage" */
+export interface SendMessage {
+  from: string;
+  to?: string;
+  content: string;
+  thread?: string;
+}
+
+/** Response "MessageAck" */
+export interface MessageAck {
+  status?: string;
+}
+
+/** Event name → 生成 interface の map for "messaging" (= type-narrowing 用) */
+export interface MessagingChannelEventTypes {
+  CCMessage: CCMessage;
+}
+
+/** Request name → { request, response } 生成 interface の map for "messaging" */
+export interface MessagingChannelRequestTypes {
+  SendMessage: { request: SendMessage; response: MessageAck };
+}
+
+/** Channel metadata for "messaging" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const MessagingChannelMeta = {
+  name: "messaging" as const,
+  backend: "stream" as const,
+  from: "either" as const,
+  lifetime: "persistent" as const,
+  events: ["CCMessage"] as const,
+  requests: {
+    SendMessage: { request: "SendMessage" as const, response: "MessageAck" as const },
+  } as const,
+  __types: undefined as unknown as { events: MessagingChannelEventTypes; requests: MessagingChannelRequestTypes },
+} as const;
+
+
+// ════════════════════════════════════════════════
+// Channel: urgent (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Event "Alert" */
+export interface Alert {
+  level: string;
+  title: string;
+  body?: string;
+}
+
+/** Event name → 生成 interface の map for "urgent" (= type-narrowing 用) */
+export interface UrgentChannelEventTypes {
+  Alert: Alert;
+}
+
+/** Request name → { request, response } 生成 interface の map for "urgent" */
+export type UrgentChannelRequestTypes = Record<string, never>;
+
+/** Channel metadata for "urgent" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const UrgentChannelMeta = {
+  name: "urgent" as const,
+  backend: "stream" as const,
+  from: "server" as const,
+  lifetime: "transient" as const,
+  events: ["Alert"] as const,
+  requests: {} as const,
+  __types: undefined as unknown as { events: UrgentChannelEventTypes; requests: UrgentChannelRequestTypes },
+} as const;
+
+

--- a/crates/unison-protocol/tests/fixtures/codegen/hierophant.rs.txt
+++ b/crates/unison-protocol/tests/fixtures/codegen/hierophant.rs.txt
@@ -1,0 +1,110 @@
+use serde :: {
+    Deserialize ,
+    Serialize
+}; use anyhow :: Result; use chrono :: {
+    DateTime ,
+    Utc
+}; use uuid :: Uuid; use std :: collections :: HashMap; # [allow (unused_imports)] use crate :: network :: {
+    ProtocolClient ,
+    ProtocolServer
+}; # [allow (unused_imports)] use crate :: network :: channel :: UnisonChannel; # [allow (unused_imports)] use crate :: network :: datagram_channel :: DatagramChannel; # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Register {
+    pub session_name : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Registered {
+    pub session_id : String ,
+    pub issued_at : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Unregister; # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Unregistered {
+    pub ok : bool
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Send {
+    pub to : String ,
+    pub payload : serde_json :: Value ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub reply_to : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Sent {
+    pub message_id : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Received {
+    pub from : String ,
+    pub payload : serde_json :: Value ,
+    pub message_id : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub reply_to : Option < String > ,
+    pub timestamp : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Publish {
+    pub topic : String ,
+    pub payload : serde_json :: Value
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Published {
+    pub message_id : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub subscriber_count : Option < i64 >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Subscribe {
+    pub topic_pattern : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Subscribed {
+    pub subscription_id : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Unsubscribe {
+    pub subscription_id : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Unsubscribed {
+    pub ok : bool
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct TopicEvent {
+    pub subscription_id : String ,
+    pub topic : String ,
+    pub payload : serde_json :: Value ,
+    pub message_id : String ,
+    pub timestamp : String
+} # [doc = r" インメモリチャネルベースのConnection（テスト用）"] pub struct HierophantConnection {
+    pub identity : UnisonChannel ,
+    pub pubsub : UnisonChannel
+} # [doc = r" QUICストリームベースのConnection（本番用）"] pub struct HierophantQuicConnection {
+    pub identity : UnisonChannel ,
+    pub pubsub : UnisonChannel
+} # [doc = r" ConnectionBuilderトレイト"] pub trait HierophantConnectionBuilder {
+    fn build (client : & crate :: network :: client :: ProtocolClient ,) -> impl std :: future :: Future < Output = Result < HierophantQuicConnection >> + Send;
+} impl HierophantConnectionBuilder for HierophantQuicConnection {
+    async fn build (client : & crate :: network :: client :: ProtocolClient ,) -> Result < HierophantQuicConnection > {
+    Ok (HierophantQuicConnection {
+    identity : client . open_channel ("identity") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "identity" ,
+    e)) ? ,
+    pubsub : client . open_channel ("pubsub") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "pubsub" ,
+    e)) ?
+})
+}
+}

--- a/crates/unison-protocol/tests/fixtures/codegen/hierophant.ts.txt
+++ b/crates/unison-protocol/tests/fixtures/codegen/hierophant.ts.txt
@@ -1,0 +1,155 @@
+// Auto-generated TypeScript definitions
+// DO NOT EDIT MANUALLY
+
+export type Timestamp = string; // ISO-8601 format
+export type UUID = string;
+export type LanguageCode = string; // ISO 639-1 format
+
+// Namespace: club.chronista.vp.hierophant
+// Version: 0.1.0
+
+// ════════════════════════════════════════════════
+// Channel: identity (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Event "Received" */
+export interface Received {
+  from: string;
+  payload: any;
+  message_id: string;
+  reply_to?: string;
+  timestamp: string;
+}
+
+/** Request "Register" */
+export interface Register {
+  session_name: string;
+}
+
+/** Response "Registered" */
+export interface Registered {
+  session_id: string;
+  issued_at: string;
+}
+
+/** Request "Unregister" — empty payload */
+export interface Unregister {}
+
+/** Response "Unregistered" */
+export interface Unregistered {
+  ok: boolean;
+}
+
+/** Request "Send" */
+export interface Send {
+  to: string;
+  payload: any;
+  reply_to?: string;
+}
+
+/** Response "Sent" */
+export interface Sent {
+  message_id: string;
+}
+
+/** Event name → 生成 interface の map for "identity" (= type-narrowing 用) */
+export interface IdentityChannelEventTypes {
+  Received: Received;
+}
+
+/** Request name → { request, response } 生成 interface の map for "identity" */
+export interface IdentityChannelRequestTypes {
+  Register: { request: Register; response: Registered };
+  Unregister: { request: Unregister; response: Unregistered };
+  Send: { request: Send; response: Sent };
+}
+
+/** Channel metadata for "identity" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const IdentityChannelMeta = {
+  name: "identity" as const,
+  backend: "stream" as const,
+  from: "client" as const,
+  lifetime: "persistent" as const,
+  events: ["Received"] as const,
+  requests: {
+    Register: { request: "Register" as const, response: "Registered" as const },
+    Unregister: { request: "Unregister" as const, response: "Unregistered" as const },
+    Send: { request: "Send" as const, response: "Sent" as const },
+  } as const,
+  __types: undefined as unknown as { events: IdentityChannelEventTypes; requests: IdentityChannelRequestTypes },
+} as const;
+
+
+// ════════════════════════════════════════════════
+// Channel: pubsub (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Event "TopicEvent" */
+export interface TopicEvent {
+  subscription_id: string;
+  topic: string;
+  payload: any;
+  message_id: string;
+  timestamp: string;
+}
+
+/** Request "Publish" */
+export interface Publish {
+  topic: string;
+  payload: any;
+}
+
+/** Response "Published" */
+export interface Published {
+  message_id: string;
+  subscriber_count?: number;
+}
+
+/** Request "Subscribe" */
+export interface Subscribe {
+  topic_pattern: string;
+}
+
+/** Response "Subscribed" */
+export interface Subscribed {
+  subscription_id: string;
+}
+
+/** Request "Unsubscribe" */
+export interface Unsubscribe {
+  subscription_id: string;
+}
+
+/** Response "Unsubscribed" */
+export interface Unsubscribed {
+  ok: boolean;
+}
+
+/** Event name → 生成 interface の map for "pubsub" (= type-narrowing 用) */
+export interface PubsubChannelEventTypes {
+  TopicEvent: TopicEvent;
+}
+
+/** Request name → { request, response } 生成 interface の map for "pubsub" */
+export interface PubsubChannelRequestTypes {
+  Publish: { request: Publish; response: Published };
+  Subscribe: { request: Subscribe; response: Subscribed };
+  Unsubscribe: { request: Unsubscribe; response: Unsubscribed };
+}
+
+/** Channel metadata for "pubsub" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const PubsubChannelMeta = {
+  name: "pubsub" as const,
+  backend: "stream" as const,
+  from: "client" as const,
+  lifetime: "persistent" as const,
+  events: ["TopicEvent"] as const,
+  requests: {
+    Publish: { request: "Publish" as const, response: "Published" as const },
+    Subscribe: { request: "Subscribe" as const, response: "Subscribed" as const },
+    Unsubscribe: { request: "Unsubscribe" as const, response: "Unsubscribed" as const },
+  } as const,
+  __types: undefined as unknown as { events: PubsubChannelEventTypes; requests: PubsubChannelRequestTypes },
+} as const;
+
+

--- a/crates/unison-protocol/tests/fixtures/codegen/ping_pong.rs.txt
+++ b/crates/unison-protocol/tests/fixtures/codegen/ping_pong.rs.txt
@@ -1,0 +1,54 @@
+use serde :: {
+    Deserialize ,
+    Serialize
+}; use anyhow :: Result; use chrono :: {
+    DateTime ,
+    Utc
+}; use uuid :: Uuid; use std :: collections :: HashMap; # [allow (unused_imports)] use crate :: network :: {
+    ProtocolClient ,
+    ProtocolServer
+}; # [allow (unused_imports)] use crate :: network :: channel :: UnisonChannel; # [allow (unused_imports)] use crate :: network :: datagram_channel :: DatagramChannel; # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Ping {
+    pub message : String
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Pong {
+    pub reply : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub timestamp : Option < String >
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Echo {
+    pub data : serde_json :: Value
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct EchoResult {
+    pub data : serde_json :: Value
+} # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct Health; # [derive (Debug ,
+    Clone ,
+    Serialize ,
+    Deserialize)] pub struct HealthStatus {
+    pub status : String ,
+    # [serde (skip_serializing_if = "Option::is_none")] pub uptime_ms : Option < i64 >
+} # [doc = r" インメモリチャネルベースのConnection（テスト用）"] pub struct PingPongConnection {
+    pub ping_pong : UnisonChannel
+} # [doc = r" QUICストリームベースのConnection（本番用）"] pub struct PingPongQuicConnection {
+    pub ping_pong : UnisonChannel
+} # [doc = r" ConnectionBuilderトレイト"] pub trait PingPongConnectionBuilder {
+    fn build (client : & crate :: network :: client :: ProtocolClient ,) -> impl std :: future :: Future < Output = Result < PingPongQuicConnection >> + Send;
+} impl PingPongConnectionBuilder for PingPongQuicConnection {
+    async fn build (client : & crate :: network :: client :: ProtocolClient ,) -> Result < PingPongQuicConnection > {
+    Ok (PingPongQuicConnection {
+    ping_pong : client . open_channel ("ping-pong") . await . map_err (| e | anyhow :: anyhow ! ("Failed to open channel '{}': {}" ,
+    "ping-pong" ,
+    e)) ?
+})
+}
+}

--- a/crates/unison-protocol/tests/fixtures/codegen/ping_pong.ts.txt
+++ b/crates/unison-protocol/tests/fixtures/codegen/ping_pong.ts.txt
@@ -1,0 +1,70 @@
+// Auto-generated TypeScript definitions
+// DO NOT EDIT MANUALLY
+
+export type Timestamp = string; // ISO-8601 format
+export type UUID = string;
+export type LanguageCode = string; // ISO 639-1 format
+
+// Namespace: test.ping_pong
+// Version: 2.0.0
+
+// ════════════════════════════════════════════════
+// Channel: ping-pong (backend=stream)
+// ════════════════════════════════════════════════
+
+/** Request "Ping" */
+export interface Ping {
+  message: string;
+}
+
+/** Response "Pong" */
+export interface Pong {
+  reply: string;
+  timestamp?: string;
+}
+
+/** Request "Echo" */
+export interface Echo {
+  data: any;
+}
+
+/** Response "EchoResult" */
+export interface EchoResult {
+  data: any;
+}
+
+/** Request "Health" — empty payload */
+export interface Health {}
+
+/** Response "HealthStatus" */
+export interface HealthStatus {
+  status: string;
+  uptime_ms?: number;
+}
+
+/** Event name → 生成 interface の map for "ping-pong" (= type-narrowing 用) */
+export type PingPongChannelEventTypes = Record<string, never>;
+
+/** Request name → { request, response } 生成 interface の map for "ping-pong" */
+export interface PingPongChannelRequestTypes {
+  Ping: { request: Ping; response: Pong };
+  Echo: { request: Echo; response: EchoResult };
+  Health: { request: Health; response: HealthStatus };
+}
+
+/** Channel metadata for "ping-pong" (= Phase 2 runtime SDK 用 type-narrowing 入力) */
+export const PingPongChannelMeta = {
+  name: "ping-pong" as const,
+  backend: "stream" as const,
+  from: "client" as const,
+  lifetime: "persistent" as const,
+  events: [] as const,
+  requests: {
+    Ping: { request: "Ping" as const, response: "Pong" as const },
+    Echo: { request: "Echo" as const, response: "EchoResult" as const },
+    Health: { request: "Health" as const, response: "HealthStatus" as const },
+  } as const,
+  __types: undefined as unknown as { events: PingPongChannelEventTypes; requests: PingPongChannelRequestTypes },
+} as const;
+
+

--- a/crates/unison-protocol/tests/test_codegen_snapshot.rs
+++ b/crates/unison-protocol/tests/test_codegen_snapshot.rs
@@ -1,0 +1,93 @@
+//! Codegen 回帰スナップショット
+//!
+//! club-kdl-codegen への re-base 前の現行 generator 出力を golden fixture として
+//! 凍結する。各スキーマについて Rust / TypeScript 両方を生成し、コミット済みの
+//! fixture とバイト一致を検証する。re-base 後にパイプラインを差し替えた際、
+//! 出力差分が即座にこのテストで surface する。
+//!
+//! fixture の更新: `UPDATE_CODEGEN_SNAPSHOTS=1` を立てて実行すると再生成する。
+//! generator を意図的に変更したときのみ使うこと。
+//!
+//! fixture: `tests/fixtures/codegen/<schema>.{rs,ts}.txt`
+
+use std::path::PathBuf;
+
+use unison::codegen::CodeGenerator;
+use unison::parser::TypeRegistry;
+use unison::prelude::*;
+
+/// スナップショット対象スキーマ。
+/// (論理名, KDL ファイルへのワークスペース相対パス)
+const SCHEMAS: &[(&str, &str)] = &[
+    ("ping_pong", "../../schemas/ping_pong.kdl"),
+    ("hierophant", "../../schemas/hierophant.kdl"),
+    ("creo_sync", "tests/fixtures/creo_sync.kdl"),
+];
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_dir() -> PathBuf {
+    crate_root().join("tests/fixtures/codegen")
+}
+
+/// 1 スキーマを Rust / TS で生成し、(rust, typescript) を返す。
+fn generate(schema_path: &str) -> (String, String) {
+    let abs = crate_root().join(schema_path);
+    let source = std::fs::read_to_string(&abs)
+        .unwrap_or_else(|e| panic!("スキーマ読み込み失敗 {}: {e}", abs.display()));
+
+    let parser = SchemaParser::new();
+    let parsed = parser
+        .parse(&source)
+        .unwrap_or_else(|e| panic!("スキーマパース失敗 {schema_path}: {e}"));
+    let type_registry = TypeRegistry::new();
+
+    let rust = RustGenerator::new()
+        .generate(&parsed, &type_registry)
+        .unwrap_or_else(|e| panic!("Rust 生成失敗 {schema_path}: {e}"));
+    let ts = TypeScriptGenerator::new()
+        .generate(&parsed, &type_registry)
+        .unwrap_or_else(|e| panic!("TypeScript 生成失敗 {schema_path}: {e}"));
+
+    (rust, ts)
+}
+
+/// 1 つの fixture を検証 or 更新する。
+fn check_or_update(name: &str, ext: &str, generated: &str) {
+    let path = fixture_dir().join(format!("{name}.{ext}.txt"));
+
+    if std::env::var("UPDATE_CODEGEN_SNAPSHOTS").is_ok() {
+        std::fs::create_dir_all(fixture_dir()).unwrap();
+        std::fs::write(&path, generated)
+            .unwrap_or_else(|e| panic!("fixture 書き込み失敗 {}: {e}", path.display()));
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "fixture が見つからない {}: {e}\n\
+             UPDATE_CODEGEN_SNAPSHOTS=1 で再生成してください",
+            path.display()
+        )
+    });
+
+    assert_eq!(
+        expected,
+        generated,
+        "codegen 出力が fixture {} と一致しません。\n\
+         generator を意図的に変更した場合は UPDATE_CODEGEN_SNAPSHOTS=1 で更新し、\n\
+         差分をレビューしてください。",
+        path.display()
+    );
+}
+
+#[test]
+fn snapshot_codegen_output() {
+    for (name, schema_path) in SCHEMAS {
+        let (rust, ts) = generate(schema_path);
+        check_or_update(name, "rs", &rust);
+        check_or_update(name, "ts", &ts);
+    }
+}


### PR DESCRIPTION
## 概要

club-kdl-codegen re-base (Phase 1) の Step 1。 codegen を IR ベースに載せ替える前に、 現 hand-rolled generator の出力を golden fixture として凍結し、 **回帰基準**を作る (現状 codegen test は `contains` 文字列 assert のみで、 byte 単位の基準が無い)。

## 変更
- `crates/unison-protocol/tests/fixtures/codegen/{ping_pong,hierophant,creo_sync}.{rs,ts}.txt` — 3 schema × Rust/TS = 6 fixture
- `tests/test_codegen_snapshot.rs` — fixture との byte 一致を検証する snapshot test (`UPDATE_CODEGEN_SNAPSHOTS=1` で再生成)
- 機構は plain file (insta 不採用 = 新規依存なし、 fixture 自体が re-base の参照 artifact なので可読 commit が良い)

## behavior-preserving
generator (`rust.rs`/`typescript.rs`) は無改修。 fixture + test を**追加するだけ**。

## 検証
`cargo test --workspace` 全 green (snapshot test 含む) / `cargo clippy --lib --workspace -D warnings` clean / `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)