### PR TITLE
chore(clients/typescript): .npmrc を gitignore に追加

### DIFF
--- a/clients/typescript/.gitignore
+++ b/clients/typescript/.gitignore
@@ -4,3 +4,6 @@ coverage/
 .vite/
 *.log
 .DS_Store
+
+# npm auth — token は 1Password (Engineering vault) 管理、 ${NPM_TOKEN} で注入
+.npmrc


### PR DESCRIPTION
## 概要

`@chronista-club/unison-client` の npm publish 配線で導入した `clients/typescript/.npmrc` を gitignore 対象に追加する。

## 詳細

- `.npmrc` の中身は `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` のみで **secret は含まない**（token 値は 1Password の `Engineering` vault 管理、`NPM_TOKEN` env で注入）
- npm の auth 設定ファイルは慣例通り追跡対象外にする
- `1.0.0-rc.1` は本配線で publish 済み（registry 反映・実 install 検証済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)