### PR TITLE
chore(release): Rust crate を 1.0.0-rc.1 に揃える

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "1.0.0-rc.1"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/crates/unison-agent/Cargo.toml
+++ b/crates/unison-agent/Cargo.toml
@@ -16,7 +16,7 @@ claude-agent-sdk = "0.1.1"
 futures = "0.3"
 
 # club-unison: crates.io package、lib identifier は `unison`
-club-unison = { path = "../unison-protocol", version = "0.10.1" }
+club-unison = { path = "../unison-protocol" }
 
 # Workspace dependencies
 tokio = { workspace = true }


### PR DESCRIPTION
## 概要

Rust workspace の Cargo version を `0.10.1` → `1.0.0-rc.1` に bump。

rc.1 cut（PR #44）時に CHANGELOG・git tag `v1.0.0-rc.1`・npm TS SDK は `1.0.0-rc.1` に上げたが、**Rust workspace の Cargo version は `0.10.1` のまま漏れていた**。crates.io の `club-unison` が npm の TS SDK と世代ズレ（Rust 0.10.1 / TS 1.0.0-rc.1）しており、公開 crate だけでは同世代の polyglot dogfood（v1.0 Rust server ↔ v1.0 TS client）が組めない。

## 変更

- workspace version `0.10.1` → `1.0.0-rc.1`
- `unison-agent` の `club-unison` path 依存から旧 `version = "0.10.1"` を除去（`publish = false` なので version 不要、prerelease 解決と整合、`unison-cli` / `unison-mcp-probe` と統一）

## 検証

`cargo check` green。CHANGELOG は rc.1 entry 既存。

merge 後に `cargo publish -p club-unison` で crates.io へ（`unison-cli` / `-agent` / `-mcp-probe` は `publish = false`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)