### PR TITLE
feat(unison-cli): unison call サブコマンド追加 + ping identity 表示

### DIFF
--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -27,7 +27,7 @@ Ruby (require "unison")
 require "unison"
 
 client = Unison::Client.new
-client.connect("https://127.0.0.1:4433")
+client.connect("quic://[::1]:7878")
 
 ch = client.open_channel("greeter")
 ch.request("Hello", { "name" => "Mako" })   #=> レスポンス Hash

--- a/crates/unison-cli/src/call.rs
+++ b/crates/unison-cli/src/call.rs
@@ -1,0 +1,84 @@
+//! `unison call <url> --channel <name> --method <name>` — channel に request を
+//! 1 本送り、response を表示する dev tool。
+//!
+//! `mock`（サーバ側の stub 応答）と対になるクライアント側コマンド。channel を
+//! open し、typed request を 1 回送って response payload を JSON で stdout に
+//! 出して終了する。`mock` を別ターミナルで起動すれば、CLI だけで
+//! request/response ループを閉じられる。
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Args;
+use unison::ProtocolClient;
+use unison::network::quic::QuicClient;
+
+use crate::TrustMode;
+
+#[derive(Args)]
+pub struct CallArgs {
+    /// Unison サーバの URL (例: `quic://[::1]:7878`)
+    pub url: String,
+
+    /// request を送る channel 名
+    #[arg(short, long)]
+    pub channel: String,
+
+    /// 呼び出す request method 名
+    #[arg(short, long)]
+    pub method: String,
+
+    /// request payload (JSON 文字列、省略時は空 object `{}`)
+    #[arg(short, long, default_value = "{}")]
+    pub payload: String,
+
+    /// trust anchor mode (default: skip)
+    #[arg(long, value_enum, default_value = "skip")]
+    pub trust: TrustMode,
+
+    /// response 待ちタイムアウト (ミリ秒、省略時は channel 既定値)
+    #[arg(long)]
+    pub timeout: Option<u64>,
+}
+
+pub async fn run(args: CallArgs) -> Result<()> {
+    // payload を JSON として検証 (= 不正なら connect 前に即エラー)
+    let payload: serde_json::Value = serde_json::from_str(&args.payload)
+        .with_context(|| format!("--payload is not valid JSON: {}", args.payload))?;
+
+    let quic = QuicClient::builder()
+        .trust_anchors(args.trust.to_anchors())
+        .build()
+        .context("QUIC client init failed")?;
+    let client = ProtocolClient::new(quic);
+
+    client.connect(&args.url).await.context("connect failed")?;
+    eprintln!(
+        "connected to {} — opening channel '{}'",
+        args.url, args.channel
+    );
+
+    let channel = {
+        let ch = client
+            .open_channel(&args.channel)
+            .await
+            .context("open_channel failed")?;
+        match args.timeout {
+            Some(ms) => ch.with_request_timeout(Duration::from_millis(ms)),
+            None => ch,
+        }
+    };
+
+    eprintln!("→ request '{}'", args.method);
+    let response: serde_json::Value = channel
+        .request(&args.method, &payload)
+        .await
+        .context("request failed")?;
+
+    // response payload を pretty JSON で stdout に出す (= CLI の primary output)
+    println!("{}", serde_json::to_string_pretty(&response)?);
+
+    let _ = channel.close().await;
+    let _ = client.disconnect().await;
+    Ok(())
+}

--- a/crates/unison-cli/src/main.rs
+++ b/crates/unison-cli/src/main.rs
@@ -6,12 +6,14 @@
 //! # サブコマンド
 //!
 //! - `ping <url>`        — サーバへ接続し疎通 + RTT 計測
+//! - `call <url>`        — channel に request を 1 本送り response を表示
 //! - `sniff <url>`       — channel traffic を覗く packet inspector
 //! - `mock --schema F`   — KDL schema から stub server を起動
 //! - `schema-lint F`     — KDL schema を parse + invariant 検証
 
 use clap::{Parser, Subcommand};
 
+mod call;
 mod mock;
 mod ping;
 mod schema_lint;
@@ -29,6 +31,8 @@ struct Cli {
 enum Command {
     /// サーバへ接続して疎通確認 + ラウンドトリップ遅延を計測する
     Ping(ping::PingArgs),
+    /// channel に request を 1 本送り response を表示する
+    Call(call::CallArgs),
     /// サーバへ接続し channel traffic を覗く (dev packet inspector)
     Sniff(sniff::SniffArgs),
     /// KDL channel schema から stub 応答する mock server を起動する
@@ -51,13 +55,14 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Ping(args) => ping::run(args).await,
+        Command::Call(args) => call::run(args).await,
         Command::Sniff(args) => sniff::run(args).await,
         Command::Mock(args) => mock::run(args).await,
         Command::SchemaLint(args) => schema_lint::run(args),
     }
 }
 
-/// `--trust` フラグ共通定義 (= ping / sniff で共有)
+/// `--trust` フラグ共通定義 (= ping / call / sniff で共有)
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
 pub enum TrustMode {
     /// cert 検証を skip (dev 用、self-signed server 向け)

--- a/crates/unison-cli/src/ping.rs
+++ b/crates/unison-cli/src/ping.rs
@@ -30,9 +30,17 @@ pub async fn run(args: PingArgs) -> Result<()> {
     println!("PING {} (trust={:?})", args.url, args.trust);
 
     let mut samples: Vec<Duration> = Vec::with_capacity(args.count as usize);
+    let mut identity_shown = false;
     for seq in 1..=args.count {
         match probe_once(&args).await {
-            Ok(rtt) => {
+            Ok((rtt, identity)) => {
+                if !identity_shown {
+                    match &identity {
+                        Some(id) => println!("  server: {id}"),
+                        None => println!("  server: <identity 未受信>"),
+                    }
+                    identity_shown = true;
+                }
                 println!("  seq={seq:<3} connected  time={:.2}ms", ms(rtt));
                 samples.push(rtt);
             }
@@ -70,8 +78,8 @@ pub async fn run(args: PingArgs) -> Result<()> {
     Ok(())
 }
 
-/// 1 回 connect して RTT を返す。
-async fn probe_once(args: &PingArgs) -> Result<Duration> {
+/// 1 回 connect して RTT と server identity を返す。
+async fn probe_once(args: &PingArgs) -> Result<(Duration, Option<String>)> {
     let quic = QuicClient::builder()
         .trust_anchors(args.trust.to_anchors())
         .build()
@@ -82,8 +90,14 @@ async fn probe_once(args: &PingArgs) -> Result<Duration> {
     client.connect(&args.url).await.context("connect failed")?;
     let rtt = start.elapsed();
 
+    // Identity Handshake で受信済みの server identity (= 接続先の確認用)
+    let identity = client
+        .server_identity()
+        .await
+        .map(|id| format!("{} v{} ({})", id.name, id.version, id.namespace));
+
     let _ = client.disconnect().await;
-    Ok(rtt)
+    Ok((rtt, identity))
 }
 
 fn ms(d: Duration) -> f64 {


### PR DESCRIPTION
## 概要

`unison` CLI の機能を見直し、**channel のカバレッジ非対称**を解消する。

これまで CLI は `mock`（サーバ側の request 応答）と `sniff`（クライアント側の event 受信）を持っていたが、**request を送る**コマンドが無かった。プロトコルの最も基本的なクライアント操作が CLI から叩けない状態だった。

## 変更

### 1. `unison call` — 新コマンド（request/response）

```
unison call <url> -c <channel> -m <method> [-p '<json>'] [--timeout <ms>]
```

channel を open し、typed request を 1 本送り、response payload を pretty JSON で stdout に出力して終了。`mock` と対になり、CLI だけで request/response ループが閉じる。

```console
$ unison call quic://[::1]:7878 -c ping-pong -m Ping -p '{"message":"hi"}'
{
  "reply": "",
  "timestamp": ""
}
```

### 2. `ping` に server identity 表示

QUIC connect は Identity Handshake を含むのに CLI に出口が無かった。接続時に `server: <name> v<version> (<namespace>)` を 1 行表示する（新コマンドは作らず `ping` 内で完結）。

```console
$ unison ping quic://[::1]:7878 -c 2
PING quic://[::1]:7878 (trust=Skip)
  server: unison-mock:ping-pong v1.0.0-rc.1 (mock)
  seq=1   connected  time=9.01ms
  ...
```

### 3. 接続 URL の canonical scheme を `quic://` に統一

`connect` は `quic://` / `https://` / `http://` / bare `host:port` を全て受理する（scheme は optional strip）が、surface ごとに表記がバラついていた。canonical を `quic://` に決め、Ruby client README の例も追従（`https://...` → `quic://...`）。

## 非ゴール（意図的に揃えない決定）

- `unison gen`（codegen）— `club-kdl-codegen` に完全移管済み。CLI に戻さない
- datagram channel の CLI 操作 — 既知ギャップ、niche、今回は対象外

## 検証

`unison mock --schema schemas/ping_pong.kdl` 相手に `call`（Ping / Health / 不正 JSON）・`ping` を動作確認。`cargo fmt` OK、新規コードは clippy 警告ゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)