### PR TITLE
chore(release): workspace version を 1.0.0-rc.2 に bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2026-05-19 — polyglot client 拡充 + CLI request/response 被覆
+
+> rc.1 以降の追補。Ruby client gem を新設し、`unison` CLI に request 送信コマンドを追加して channel の request/event 両半分を CLI で被覆した。
+
+### 追加 — Ruby client gem (`unison-client`)
+
+- `clients/ruby/` — Rust `club-unison` crate を Magnus native 拡張で wrap する言語バインディング（protocol 再実装ではない）
+- `Unison::Client`（接続ライフサイクル + `open_channel`）/ `Unison::Channel`（`request` / `send_event` / `recv` / `close`）/ `Unison::Error` (`< StandardError`)
+- channel payload は native Ruby 値 ⇄ `serde_json::Value` を `serde_magnus` で双方向変換
+- ブロッキング呼び出しは `rb_thread_call_without_gvl` で GVL を解放
+
+### 追加 — `unison call` サブコマンド
+
+- `unison call <url> -c <channel> -m <method> [-p <json>] [--timeout <ms>]` — channel に request を 1 本送り response を pretty JSON 出力
+- `mock`（サーバ応答）と対になり、CLI だけで request/response ループが閉じる
+
+### 変更 — `unison ping`
+
+- 接続時に server identity（name / version / namespace）を表示
+
+### 変更 — 接続 URL scheme
+
+- canonical scheme を `quic://` に統一（`connect` は `quic://` / `https://` / `http://` / bare を受理）
+
 ## [1.0.0-rc.1] - 2026-05-17 — v1.0 polyglot client base (release candidate)
 
 > v1.0 sprint「polyglot client base」 の release candidate。 TypeScript client SDK を新設し、 **browser から Rust server へ実 WebTransport で接続**できる状態に到達。 dogfood 開始点 (= Vantage Point ほか chronista-club ecosystem での実利用検証)。 GA は dogfood exit criteria (3+ caller × 実運用 × critical bug 0) 達成後。

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"


### PR DESCRIPTION
## 概要

`unison` 本体（`club-unison` workspace）のバージョンを `1.0.0-rc.1` → `1.0.0-rc.2` に bump する。

rc.1 以降にマージされた追補を反映:
- #49 — Ruby client gem (`unison-client`)
- #50 — `unison call` サブコマンド + `ping` identity 表示

## 変更

- `Cargo.toml` の `[workspace.package].version`: `1.0.0-rc.1` → `1.0.0-rc.2`（workspace 全 crate に波及）
- `CHANGELOG.md` に `[1.0.0-rc.2]` セクションを追加

## 補足

- `club-unison`（lib crate）のコード自体は rc.1 から不変。今回の追補は CLI（`unison-cli`、`publish = false`）と Ruby gem。crates.io への publish は別判断
- `unison --version` → `1.0.0-rc.2` を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)