### PR TITLE
test(clients/ruby): Ruby client の実サーバ E2E テストを追加

### DIFF
--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -53,15 +53,19 @@ refinement）。
 
 失敗はすべて `Unison::Error`（`< StandardError`）として raise される。
 
-次フェーズ: 実 Unison サーバ相手の E2E テスト。
+次フェーズ: GVL 解放中の呼び出しの中断（unblock function）、`recv` の timeout 版。
 
 ## ビルド・テスト
 
 ```
 bundle install
-bundle exec rake compile   # native 拡張をビルド
-bundle exec rake test      # compile → minitest
+bundle exec rake compile    # native 拡張をビルド
+bundle exec rake test       # compile → 単体テスト（ネットワーク不要）
+bundle exec rake test:e2e   # compile → E2E（`unison mock` を subprocess 起動）
 ```
+
+`rake test:e2e` は `unison` バイナリ（`cargo build -p unison-cli` で生成、または
+`UNISON_MOCK_BIN` で指定）を要する。見つからない場合は skip される。
 
 **Ruby 3.4 以上が必須。** 開発環境の version は `.mise.toml` に固定（現在 3.4.9）。
 

--- a/clients/ruby/Rakefile
+++ b/clients/ruby/Rakefile
@@ -11,11 +11,24 @@ RbSys::ExtensionTask.new("unison_client", GEMSPEC) do |ext|
   ext.lib_dir = "lib/unison_client"
 end
 
-# テストは native 拡張に依存するため compile を前提タスクにする。
+# 単体テスト（test/ 直下、ネットワーク不要）。native 拡張に依存するため
+# compile を前提タスクにする。
 Rake::TestTask.new(test: :compile) do |t|
   t.libs << "test" << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = FileList["test/*_test.rb"]
   t.warning = false
 end
+
+namespace :test do
+  # E2E テスト（test/e2e/、`unison mock` を subprocess 起動）。
+  # `unison` バイナリが無い環境では各テストが skip される。
+  Rake::TestTask.new(:e2e) do |t|
+    t.libs << "test" << "lib"
+    t.test_files = FileList["test/e2e/*_test.rb"]
+    t.warning = false
+  end
+end
+# `test:e2e` も native 拡張を要するため compile を前提に（root の compile を明示）。
+task "test:e2e" => :compile
 
 task default: :test

--- a/clients/ruby/test/e2e/connect_test.rb
+++ b/clients/ruby/test/e2e/connect_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "socket"
+require "tempfile"
+require "unison"
+
+# 実 Unison サーバ（`unison mock`）相手の E2E テスト。
+#
+# `unison mock` を subprocess で起動し、Ruby client から QUIC 接続して
+# connect / open_channel / request / send_event / disconnect を検証する。
+#
+# `unison` バイナリが見つからない場合は skip するので、binary 未ビルドの環境
+# でも `rake test:e2e` は緑のまま（バイナリは `cargo build -p unison-cli` で
+# 生成、または `UNISON_MOCK_BIN` で明示）。
+class ConnectE2ETest < Minitest::Test
+  SCHEMA = File.expand_path("../fixtures/ping_pong.kdl", __dir__)
+
+  def setup
+    @bin = find_unison_bin
+    skip "unison binary not found — build it: cargo build -p unison-cli" unless @bin
+
+    @port = free_udp_port
+    @addr = "[::1]:#{@port}"
+    @log = Tempfile.new("unison-mock")
+    @server = spawn(@bin, "mock", "--schema", SCHEMA, "--addr", @addr,
+                    out: @log.path, err: [:child, :out])
+    wait_until_listening
+  end
+
+  def teardown
+    if @server
+      Process.kill("TERM", @server)
+      Process.wait(@server)
+    end
+    @log&.close!
+  rescue Errno::ESRCH, Errno::ECHILD
+    # プロセスは既に終了・回収済み
+  end
+
+  def test_connect_open_channel_request_disconnect
+    client = Unison::Client.new
+    client.connect("quic://#{@addr}")
+    assert client.connected?, "client should be connected after #connect"
+
+    ch = client.open_channel("ping-pong")
+
+    # `unison mock` は schema の `returns` 型から決定的な stub を返す
+    # （string→"" / int→0 / json→{}）。
+    assert_equal({ "reply" => "", "timestamp" => "" },
+                 ch.request("Ping", { "message" => "hello" }))
+    assert_equal({ "status" => "", "uptime_ms" => 0 },
+                 ch.request("Health", {}))
+    assert_equal({ "data" => {} },
+                 ch.request("Echo", { "data" => { "k" => "v" } }))
+
+    # fire-and-forget event — mock は受け流すだけ。送信が raise しないこと。
+    ch.send_event("Ping", { "message" => "evt" })
+
+    ch.close
+    client.disconnect
+    refute client.connected?, "client should be disconnected after #disconnect"
+  end
+
+  private
+
+  # `unison` バイナリを探す: UNISON_MOCK_BIN → target/release → target/debug。
+  def find_unison_bin
+    env = ENV["UNISON_MOCK_BIN"]
+    return env if env && File.executable?(env)
+
+    root = File.expand_path("../../../..", __dir__) # club-unison repo root
+    %w[release debug].each do |profile|
+      path = File.join(root, "target", profile, "unison")
+      return path if File.executable?(path)
+    end
+    nil
+  end
+
+  # QUIC は UDP。空き UDP ポートを 1 つ確保して返す。
+  def free_udp_port
+    sock = UDPSocket.new(Socket::AF_INET6)
+    sock.bind("::1", 0)
+    sock.addr[1]
+  ensure
+    sock&.close
+  end
+
+  # mock が "listening on" を出力するまで待つ。即死した場合はログ付きで失敗。
+  def wait_until_listening(timeout: 15)
+    deadline = Time.now + timeout
+    loop do
+      raise "unison mock did not become ready within #{timeout}s" if Time.now > deadline
+      return if File.read(@log.path).include?("listening on")
+
+      if Process.wait2(@server, Process::WNOHANG)
+        @server = nil
+        raise "unison mock exited early:\n#{File.read(@log.path)}"
+      end
+      sleep 0.1
+    end
+  end
+end

--- a/clients/ruby/test/e2e/connect_test.rb
+++ b/clients/ruby/test/e2e/connect_test.rb
@@ -33,9 +33,11 @@ class ConnectE2ETest < Minitest::Test
       Process.kill("TERM", @server)
       Process.wait(@server)
     end
-    @log&.close!
   rescue Errno::ESRCH, Errno::ECHILD
     # プロセスは既に終了・回収済み
+  ensure
+    # rescue 経路でも Tempfile を確実に unlink する。
+    @log&.close!
   end
 
   def test_connect_open_channel_request_disconnect

--- a/clients/ruby/test/fixtures/ping_pong.kdl
+++ b/clients/ruby/test/fixtures/ping_pong.kdl
@@ -1,0 +1,29 @@
+protocol "ping-pong" version="2.0.0" {
+    namespace "test.ping_pong"
+
+    channel "ping-pong" from="client" lifetime="persistent" {
+        request "Ping" {
+            field "message" type="string" required=#true
+
+            returns "Pong" {
+                field "reply" type="string" required=#true
+                field "timestamp" type="string"
+            }
+        }
+
+        request "Echo" {
+            field "data" type="json" required=#true
+
+            returns "EchoResult" {
+                field "data" type="json" required=#true
+            }
+        }
+
+        request "Health" {
+            returns "HealthStatus" {
+                field "status" type="string" required=#true
+                field "uptime_ms" type="int"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Ruby client（`unison-client` gem）の **実 Unison サーバ相手の E2E テスト**を追加する。これまでの単体テストは非ネットワーク範囲のみだった。

`unison mock` を subprocess で起動し、Ruby client から QUIC 接続して接続ライフサイクル + channel request/response を検証する。

## 変更

- **`test/e2e/connect_test.rb`** — `unison mock`（`ping_pong` schema）相手の E2E。`connect` → `open_channel("ping-pong")` → `request`（Ping / Health / Echo）→ `send_event` → `disconnect` を検証。mock は schema の `returns` 型から決定的 stub を返すので応答を exact assert
- **`test/fixtures/ping_pong.kdl`** — schema fixture（gem 内で自己完結、repo の `schemas/` に依存しない）
- **`Rakefile`** — `rake test`（単体、`test/*_test.rb`）と `rake test:e2e`（`test/e2e/*_test.rb`）を分離。`test` は E2E を拾わない
- `unison` バイナリ未検出時は E2E を skip（`UNISON_MOCK_BIN` で上書き可）— バイナリ未ビルドの環境でも緑

## 検証

| タスク | 結果 |
|--------|------|
| `rake test`（単体） | 6 runs, 6 assertions, 0 failures |
| `rake test:e2e`（E2E） | 1 runs, 5 assertions, 0 failures — `unison mock` に実 QUIC 接続 |

## 補足

- E2E は `unison mock` を使うため `unison` バイナリ（`cargo build -p unison-cli`）が必要。CI への配線は別途
- `recv` は mock がイベントを push しないため E2E 対象外（request/response のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)