### PR TITLE
chore(deps): club-kdl を 0.5 → 0.8 に更新

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ indexmap = "2.14"
 scc = "3"
 tempfile = "3.27"
 kdl = "6.5.0"
-club-kdl = "0.5"
+club-kdl = "0.8"
 
 # Dev dependencies
 pretty_assertions = "1.4"


### PR DESCRIPTION
## 概要

`club-kdl` 依存を `0.5` → **`0.8`**（crates.io 最新）に更新する。dogfood 推進のため tooling を最新へ追従。

## 変更

- `Cargo.toml`（`[workspace.dependencies]`）: `club-kdl = "0.5"` → `"0.8"`

## 影響範囲・互換性

club-unison は `club-kdl` を **KDL パース**（`crates/unison-protocol/src/parser/` の `club_kdl::from_str` / `club_kdl::KdlDeserialize`）にのみ使用。codegen は `club-kdl-codegen` に分離済みで非依存。

- `club-kdl 0.8` の BREAKING 変更は **codegen 側**（`field` デフォルトの required 反転）であり、club-unison が使う parse 面 API は不変
- `club-kdl 0.8` の `kdl` 依存は `"6"` で、club-unison の `kdl = "6.5.0"` と互換
- 呼び出し側の修正は不要

## 検証

| チェック | 結果 |
|---------|------|
| `cargo check --workspace` | クリーン通過 |
| `cargo test -p club-unison`（parser テスト） | 全 pass / 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)