### PR TITLE
test(clients/ruby): Ruby client ベンチマークを追加

### DIFF
--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -69,6 +69,17 @@ bundle exec rake test:e2e   # compile → E2E（`unison mock` を subprocess 起
 
 **Ruby 3.4 以上が必須。** 開発環境の version は `.mise.toml` に固定（現在 3.4.9）。
 
+## ベンチマーク
+
+```
+ruby bench/bench.rb > bench/runs/<date>-<tag>.kdl
+```
+
+`unison mock` を subprocess 起動し、(1) `Channel#request` の RTT / throughput と
+(2) GVL 解放の効果（ブロッキング呼び出し中に背景スレッドが進む割合）を計測し、
+structured-log KDL を出力する。run は `bench/runs/` に immutable に蓄積し、
+`bench/index.kdl` が append-only インデックスとして参照する。
+
 ## 対応 protocol 世代
 
 `1.0.0-rc.1` — npm `@chronista-club/unison-client` / crates.io `club-unison`

--- a/clients/ruby/bench/bench.rb
+++ b/clients/ruby/bench/bench.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+# Ruby client ベンチマーク。
+#
+# `unison mock` を subprocess 起動し、2 つを計測して structured-log KDL を
+# stdout に出力する（進捗ログは stderr）:
+#
+#   1. channel suite — Channel#request の RTT / throughput
+#   2. gvl suite     — GVL 解放の効果。背景スレッドの spin-count throughput を
+#      main が ①idle ②Unison request ③純 Ruby CPU ループ の 3 シナリオで比較。
+#      ② が高く ③ がほぼ 0 なら「network 待ち中に GVL を解放している」の証拠。
+#
+# 使い方:
+#   ruby bench/bench.rb > bench/runs/<date>-<tag>.kdl
+#
+# `unison` バイナリが必要（`cargo build -p unison-cli`、または `UNISON_MOCK_BIN`）。
+
+require "socket"
+require "tempfile"
+
+# `lib/` を load path に追加（unison.rb 内の `require "unison_client/..."` 用）。
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "unison"
+
+VERSION = "1.0.0-rc.2"
+DATE = "2026-05-19"
+
+def clock = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+def log(msg) = warn(msg)
+
+def median(values) = values.sort[values.size / 2]
+
+def find_unison_bin
+  env = ENV["UNISON_MOCK_BIN"]
+  return env if env && File.executable?(env)
+
+  root = File.expand_path("../../..", __dir__)
+  %w[release debug].each do |profile|
+    path = File.join(root, "target", profile, "unison")
+    return path if File.executable?(path)
+  end
+  abort "unison binary not found — build it: cargo build -p unison-cli"
+end
+
+def free_udp_port
+  sock = UDPSocket.new(Socket::AF_INET6)
+  sock.bind("::1", 0)
+  sock.addr[1]
+ensure
+  sock&.close
+end
+
+# 背景スレッドに spin-count させ、`yield`（main の作業）の間に進んだ
+# カウントと所要時間を返す。GVL を main が手放している割合がそのまま
+# 背景スレッドの進捗に表れる。
+def measure_background
+  counter = 0
+  stop = false
+  bg = Thread.new do
+    counter += 1 until stop
+  end
+  Thread.pass # 背景スレッドを確実に走らせてから計測へ
+  started = clock
+  yield
+  elapsed = clock - started
+  stop = true
+  bg.join
+  [counter, elapsed]
+end
+
+# --- mock サーバ起動 ---------------------------------------------------------
+bin = find_unison_bin
+schema = File.expand_path("../test/fixtures/ping_pong.kdl", __dir__)
+port = free_udp_port
+addr = "[::1]:#{port}"
+mock_log = Tempfile.new("unison-bench-mock")
+log "starting `unison mock` on #{addr} …"
+server = spawn(bin, "mock", "--schema", schema, "--addr", addr,
+               out: mock_log.path, err: %i[child out])
+
+deadline = clock + 15
+until File.read(mock_log.path).include?("listening on")
+  abort "unison mock failed to start:\n#{File.read(mock_log.path)}" if clock > deadline
+  sleep 0.05
+end
+
+begin
+  client = Unison::Client.new
+  client.connect("quic://#{addr}")
+  channel = client.open_channel("ping-pong")
+  payload = { "message" => "bench" }
+
+  # === 1. request RTT / throughput ==========================================
+  log "warming up …"
+  300.times { channel.request("Ping", payload) }
+
+  samples_n = 3000
+  log "measuring request RTT (#{samples_n} calls) …"
+  rtt_ms = Array.new(samples_n)
+  loop_start = clock
+  samples_n.times do |i|
+    t0 = clock
+    channel.request("Ping", payload)
+    rtt_ms[i] = (clock - t0) * 1000.0
+  end
+  loop_elapsed = clock - loop_start
+  rtt_ms.sort!
+  req_hz = (samples_n / loop_elapsed).round
+  req_mean = (rtt_ms.sum / samples_n).round(4)
+  req_p50 = rtt_ms[samples_n / 2].round(4)
+  req_p99 = rtt_ms[(samples_n * 0.99).to_i].round(4)
+
+  # === 2. GVL 並行性 =========================================================
+  # 各ラウンドで idle / unison / cpu を計測し、idle を 100% としたラウンド内
+  # 比率を出す。spin-counter はスケジューラ依存でノイズが乗るため複数ラウンド
+  # の中央値を採る。
+  gvl_reqs = 2000
+  cpu_iters = 30_000_000
+  rounds = 5
+
+  unison_pcts = []
+  cpu_pcts = []
+  rounds.times do |r|
+    log "measuring GVL: round #{r + 1}/#{rounds} …"
+
+    # idle baseline — main は sleep（sleep も GVL を解放 → 背景はほぼ 100%）
+    c, e = measure_background { sleep 0.6 }
+    rate_idle = c / e
+
+    # Unison request 中 — block_on の network 待ちで GVL が解放される
+    c, e = measure_background { gvl_reqs.times { channel.request("Ping", payload) } }
+    unison_pcts << (c / e) / rate_idle * 100
+
+    # 純 Ruby CPU ループ中 — main が GVL を握る対照群（GVL タイムスライス分のみ漏れる）
+    c, e = measure_background do
+      x = 0
+      cpu_iters.times { x += 1 }
+    end
+    cpu_pcts << (c / e) / rate_idle * 100
+  end
+
+  pct_unison = median(unison_pcts).round(1)
+  pct_cpu = median(cpu_pcts).round(1)
+
+  # === KDL 出力 ==============================================================
+  arch = RUBY_PLATFORM.split("-").first
+  puts <<~KDL
+    // Unison Ruby client bench run — immutable snapshot。1 file = 1 run。
+    // 構造: benchmark > suite > case。
+    // - channel: Channel#request の hz(req/sec) / mean_ms / p50_ms / p99_ms。
+    // - gvl: 背景スレッドの spin-count throughput を idle=100% として正規化した
+    //   pct（5 ラウンド中央値）。unison > cpu の差が network 待ち中の GVL 解放分。
+    //   cpu が 0 でないのは CRuby の GVL タイムスライスによる漏れ。
+    benchmark version="#{VERSION}" date="#{DATE}" client="ruby-client" {
+        machine arch="#{arch}" ruby="#{RUBY_VERSION}" server="unison-mock"
+
+        suite "channel" {
+            case "Channel.request" hz=#{req_hz} mean_ms=#{req_mean} p50_ms=#{req_p50} p99_ms=#{req_p99} samples=#{samples_n}
+        }
+        suite "gvl" {
+            case "bg-throughput/idle"   pct=100.0
+            case "bg-throughput/unison" pct=#{pct_unison}
+            case "bg-throughput/cpu"    pct=#{pct_cpu}
+        }
+    }
+  KDL
+ensure
+  begin
+    Process.kill("TERM", server)
+    Process.wait(server)
+  rescue Errno::ESRCH, Errno::ECHILD
+    # mock は既に終了済み
+  end
+  mock_log&.close!
+end

--- a/clients/ruby/bench/index.kdl
+++ b/clients/ruby/bench/index.kdl
@@ -1,0 +1,7 @@
+// Unison Ruby client bench log — append-only index。
+// 新 run が出るたび `run` 行を 1 つ追加するだけ。各 run の実数値は ref が
+// 指す runs/*.kdl に immutable で存在する。
+// = 不変エントリ (runs/) + 成長するインデックス (このファイル) の構造。
+bench-log domain="ruby-client" {
+    run ref="runs/2026-05-19-rc.2.kdl" version="1.0.0-rc.2" date="2026-05-19"
+}

--- a/clients/ruby/bench/runs/2026-05-19-rc.2.kdl
+++ b/clients/ruby/bench/runs/2026-05-19-rc.2.kdl
@@ -1,0 +1,31 @@
+// Unison Ruby client bench run — immutable snapshot。1 file = 1 run。
+// 構造: benchmark > suite > case。
+// - channel: Channel#request の hz(req/sec) / mean_ms / p50_ms / p99_ms。
+// - gvl: 背景スレッドの spin-count throughput を idle=100% として正規化した
+//   pct（5 ラウンド中央値）。unison > cpu の差が network 待ち中の GVL 解放分。
+//   cpu が 0 でないのは CRuby の GVL タイムスライスによる漏れ。
+benchmark version="1.0.0-rc.2" date="2026-05-19" client="ruby-client" {
+    machine arch="arm64" ruby="3.4.9" server="unison-mock"
+
+    suite "channel" {
+        case "Channel.request" hz=7018 mean_ms=0.1421 p50_ms=0.13 p99_ms=0.422 samples=3000
+    }
+    suite "gvl" {
+        case "bg-throughput/idle"   pct=100.0
+        case "bg-throughput/unison" pct=86.0
+        case "bg-throughput/cpu"    pct=45.9
+    }
+
+    // honest 所感:
+    // - Channel.request: 7018 req/s (p50 0.13ms / p99 0.42ms)。loopback QUIC +
+    //   unison mock の stub 応答。実 network ではなく、Ruby ⇄ Rust 往復 + QUIC
+    //   stream + serde_magnus 変換を含めた client パスの下限性能の目安。
+    // - gvl: 背景スレッドは Unison request 中 86% の throughput を維持。GVL を
+    //   握りっぱなしの純 Ruby CPU ループ (45.9%) の ~1.9 倍。request 時間の
+    //   大半が block_on (network 待ち = GVL 解放) で、残り ~14% が GVL 保持下の
+    //   serde_magnus 変換 + ループ overhead に相当する。
+    // - cpu が 0 でなく 45.9% なのは CRuby の GVL タイムスライス (タイトな Ruby
+    //   ループでも定期的に GVL を手放す) による。これが対照群のベースライン。
+    // → 「Unison client は network 待ち中に GVL を解放し、他の Ruby スレッドを
+    //   止めない」ことが 86% vs 45.9% の差で数値的に裏付けられた。
+}


### PR DESCRIPTION
## 概要

Ruby client（`unison-client` gem）のベンチマークを追加する。`unison mock` を subprocess 起動し、structured-log KDL 形式（TS SDK bench と同じ構造）で 2 つを計測する。

## 計測内容と結果

### 1. `channel` — request RTT / throughput

| case | hz (req/s) | mean_ms | p50_ms | p99_ms |
|------|-----------|---------|--------|--------|
| `Channel.request` | 7018 | 0.142 | 0.13 | 0.42 |

loopback QUIC + mock stub での client パス下限性能の目安（Ruby ⇄ Rust 往復 + QUIC stream + serde_magnus 変換込み）。

### 2. `gvl` — GVL 解放の効果

背景スレッドの spin-count throughput を `idle=100%` として正規化し、main が ①idle ②Unison request ③純 Ruby CPU ループ の 3 シナリオで比較（5 ラウンド中央値）。

| case | pct |
|------|-----|
| `bg-throughput/idle` | 100.0 |
| `bg-throughput/unison` | **86.0** |
| `bg-throughput/cpu` | 45.9 |

→ 背景スレッドは Unison request 中 **86%** の throughput を維持。GVL を握りっぱなしの純 CPU ループ（45.9%）の **~1.9 倍**。「Unison client は network 待ち中に GVL を解放し、他の Ruby スレッドを止めない」ことを数値的に裏付けた。`cpu` が 0 でないのは CRuby の GVL タイムスライスによる漏れ（対照群のベースライン）。

## 構成

- `bench/bench.rb` — ベンチスクリプト（`ruby bench/bench.rb > bench/runs/<date>.kdl`）
- `bench/runs/2026-05-19-rc.2.kdl` — immutable な run snapshot（honest 所感つき）
- `bench/index.kdl` — append-only インデックス

## 補足

- bench は `unison` バイナリ（`cargo build -p unison-cli`）を要する
- viewer.html は今回は対象外（structured-log KDL のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)