### PR TITLE
docs(changelog): rc.2 以降の追補を [Unreleased] に記録

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 
 ## [Unreleased]
 
+> rc.2 以降の追補。クレート実体（`club-unison` lib）の API は不変で、Ruby client
+> のテスト・ベンチ追加と依存更新が中心。
+
+### 追加 — Ruby client のテスト・ベンチマーク
+
+- `clients/ruby/test/e2e/` — `unison mock` を subprocess 起動する実サーバ E2E テスト（#52）
+- `clients/ruby/bench/` — `Channel#request` の RTT/throughput と GVL 解放効果を計測するベンチマーク（structured-log KDL 形式、#54）
+
+### 変更 — 依存
+
+- `club-kdl` を `0.5` → `0.8` に更新（#53）。club-unison は KDL パース（`from_str` / `KdlDeserialize`）にのみ使用しており API 互換、呼び出し側の変更なし
+
 ## [1.0.0-rc.2] - 2026-05-19 — polyglot client 拡充 + CLI request/response 被覆
 
 > rc.1 以降の追補。Ruby client gem を新設し、`unison` CLI に request 送信コマンドを追加して channel の request/event 両半分を CLI で被覆した。


### PR DESCRIPTION
## 概要

rc.2（PR #51）以降にマージした 3 本を CHANGELOG の `[Unreleased]` セクションに記録する。バージョンは `1.0.0-rc.2` 据え置き — crates.io 未 publish かつ公開 crate `club-unison` の API は不変のため、追加 bump は不要（選択肢 A）。

## 反映内容

`[Unreleased]` に追記:

- **追加** — Ruby client のテスト・ベンチマーク
  - #52 — `clients/ruby/test/e2e/` 実サーバ E2E テスト
  - #54 — `clients/ruby/bench/` ベンチマーク（structured-log KDL）
- **変更** — 依存
  - #53 — `club-kdl` 0.5 → 0.8（KDL パースにのみ使用、API 互換）

Living Documentation 原則に従い、次の正式 bump 時にこの `[Unreleased]` がそのまま新バージョン節へ繰り上がる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)