### PR TITLE
feat(unison-protocol): trust に MeshCa private-CA primitive を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.3] - 2026-05-22 — MeshCa private-CA primitive + Ruby client 拡充
+
 > rc.2 以降の追補。`unison` trust に private-CA primitive を新設（fleetflow からの
 > dogfood handoff 発）、ほか Ruby client のテスト・ベンチと依存更新。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@
 
 ## [Unreleased]
 
-> rc.2 以降の追補。クレート実体（`club-unison` lib）の API は不変で、Ruby client
-> のテスト・ベンチ追加と依存更新が中心。
+> rc.2 以降の追補。`unison` trust に private-CA primitive を新設（fleetflow からの
+> dogfood handoff 発）、ほか Ruby client のテスト・ベンチと依存更新。
+
+### 追加 — trust: `MeshCa` private-CA primitive
+
+- `network::mesh::MeshCa` — 内部 mesh 用の private 認証局。`generate()` で CA 生成、`issue(sans)` で per-server leaf cert を CA 署名して発行（`CertSource`）、`trust_anchors()` で client 用 `TrustAnchors::Custom([CA])`、`to_pem` / `from_pem` で永続化。
+- `InternalMeshKeypair`（self-signed 1 枚の pairwise）が N server にスケールしない問題を解消 — client は CA 1 枚を信頼するだけ（O(1)）、server 追加で client 無改修、per-server key で compromise 隔離。
+- client 側は新規コード不要（`TrustAnchors::Custom` が rustls の chain 検証に乗る）。fleetflow の Podman+Quadlet epic の dogfood handoff 発。
 
 ### 追加 — Ruby client のテスト・ベンチマーク
 
@@ -18,6 +24,7 @@
 ### 変更 — 依存
 
 - `club-kdl` を `0.5` → `0.8` に更新（#53）。club-unison は KDL パース（`from_str` / `KdlDeserialize`）にのみ使用しており API 互換、呼び出し側の変更なし
+- `rcgen` の `x509-parser` feature を有効化（`MeshCa::from_pem` が CA cert PEM から `Issuer` を復元するのに必要）
 
 ## [1.0.0-rc.2] - 2026-05-19 — polyglot client 拡充 + CLI request/response 被覆
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ tokio = { version = "1.52", features = ["full"] }
 quinn = "0.11"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 rustls-pemfile = "2.2"
-rcgen = "0.14"
+# x509-parser feature: MeshCa::from_pem が CA cert PEM から Issuer を
+# 復元する (Issuer::from_ca_cert_pem) のに必要。
+rcgen = { version = "0.14", features = ["x509-parser"] }
 webpki-roots = "1.0"
 futures-util = "0.3"
 # 自己署名 cert の validity 期間設定用 (rcgen の date 型に合わせる)

--- a/crates/unison-protocol/src/network/cert.rs
+++ b/crates/unison-protocol/src/network/cert.rs
@@ -11,7 +11,8 @@
 //!
 //! | Scenario | Variant |
 //! |----------|---------|
-//! | Internal cluster mesh (server↔server) | [`CertSource::SelfSigned`] via [`InternalMeshKeypair`] |
+//! | Internal mesh, fixed server↔client pair | [`CertSource::SelfSigned`] via [`InternalMeshKeypair`] |
+//! | Internal mesh, many servers (private CA) | [`CertSource::Provided`] via [`super::mesh::MeshCa::issue`] |
 //! | Public server (Let's Encrypt etc.) | [`CertSource::Provided`] or [`CertSource::FromFile`] |
 //! | Dev quickstart (localhost only) | [`CertSource::dev_localhost`] |
 //!

--- a/crates/unison-protocol/src/network/mesh.rs
+++ b/crates/unison-protocol/src/network/mesh.rs
@@ -171,6 +171,8 @@ impl MeshCa {
         let ca_key = KeyPair::from_pem(ca_key_pem).context("MeshCa: parsing CA key PEM")?;
         let issuer = Issuer::from_ca_cert_pem(ca_cert_pem, ca_key)
             .context("MeshCa: parsing CA certificate PEM")?;
+        // `Issuer` は CA cert DER を保持しない (rcgen の設計) ため、rustls 用の
+        // trust anchor / leaf chain に渡す DER は PEM から独立に取り出す。
         let ca_cert_der = rustls_pemfile::certs(&mut ca_cert_pem.as_bytes())
             .next()
             .context("MeshCa: no certificate found in CA PEM")?
@@ -267,7 +269,9 @@ mod tests {
             panic!("trust_anchors() must be Custom");
         };
         let mut roots = RootCertStore::empty();
-        roots.add(ca_certs[0].clone()).expect("add CA to root store");
+        roots
+            .add(ca_certs[0].clone())
+            .expect("add CA to root store");
         WebPkiServerVerifier::builder_with_provider(
             Arc::new(roots),
             Arc::new(rustls::crypto::ring::default_provider()),
@@ -287,8 +291,12 @@ mod tests {
         let (cert_pem, key_pem) = ca.to_pem();
         let reloaded = MeshCa::from_pem(&cert_pem, &key_pem).expect("from_pem");
 
-        let TrustAnchors::Custom(orig) = ca.trust_anchors() else { unreachable!() };
-        let TrustAnchors::Custom(back) = reloaded.trust_anchors() else { unreachable!() };
+        let TrustAnchors::Custom(orig) = ca.trust_anchors() else {
+            unreachable!()
+        };
+        let TrustAnchors::Custom(back) = reloaded.trust_anchors() else {
+            unreachable!()
+        };
         assert_eq!(orig, back, "reloaded CA must point at the same cert");
     }
 
@@ -298,7 +306,9 @@ mod tests {
         let chain = chain_of(&ca.issue(["leaf.test".to_string()]).expect("issue"));
 
         assert_eq!(chain.len(), 2, "chain should be [leaf, ca]");
-        let TrustAnchors::Custom(ca_certs) = ca.trust_anchors() else { unreachable!() };
+        let TrustAnchors::Custom(ca_certs) = ca.trust_anchors() else {
+            unreachable!()
+        };
         assert_eq!(chain[1], ca_certs[0], "chain[1] must be the CA cert");
     }
 

--- a/crates/unison-protocol/src/network/mesh.rs
+++ b/crates/unison-protocol/src/network/mesh.rs
@@ -1,34 +1,29 @@
-//! Internal mesh helper: paired server cert + client trust anchor.
+//! Internal mesh trust helpers.
 //!
-//! # Why a pair?
+//! Two primitives for establishing TLS trust between Unison endpoints under a
+//! single operator's control, **without a public CA**:
 //!
-//! When two Unison endpoints under the same operator's control want to
-//! communicate (e.g., HG broker ↔ Heaven's Door TUI within Chronista),
-//! they need:
-//! - **Server side**: a self-signed cert with the appropriate SANs
-//! - **Client side**: a trust anchor that recognises that exact cert
+//! - [`InternalMeshKeypair`] — one self-signed cert shared by a server and its
+//!   client. Simplest; fits a single fixed pair (e.g. broker ↔ TUI).
+//! - [`MeshCa`] — a private certificate authority that signs a per-server leaf
+//!   cert. Scales to many servers: clients trust only the CA, and adding a
+//!   server needs no client-side change.
 //!
-//! [`InternalMeshKeypair::generate`] returns both halves derived from the
-//! same self-signed certificate, eliminating the need for the client to fall
-//! back to [`crate::network::trust::TrustAnchors::SkipVerification`].
-//!
-//! # Example
-//!
-//! ```no_run
-//! use unison::network::mesh::InternalMeshKeypair;
-//!
-//! let pair = InternalMeshKeypair::generate(
-//!     ["broker.local".into(), "*.unison.svc.cluster.local".into()],
-//! )?;
-//!
-//! // Server uses `pair.server_cert_source`
-//! // Client uses `pair.client_trust_anchors`
-//! # Ok::<_, anyhow::Error>(())
-//! ```
+//! Both pair with [`CertSource`] on the server and [`TrustAnchors`] on the
+//! client — the library still does not pick a trust model, it just makes the
+//! mesh quadrant ergonomic.
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose,
+};
+use rustls::crypto::ring::sign::any_supported_type;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::sign::CertifiedKey;
+use time::{Duration, OffsetDateTime};
 
 use super::cert::{CertSource, generate_self_signed_with_der};
 use super::trust::TrustAnchors;
@@ -38,6 +33,28 @@ use super::trust::TrustAnchors;
 /// Both halves are derived from a single freshly-generated self-signed cert,
 /// so the client's [`TrustAnchors::Custom`] contains exactly the cert that
 /// the server presents.
+///
+/// # When to use
+///
+/// Fits exactly one server bound to its client(s) by a shared cert (e.g. HG
+/// broker ↔ Heaven's Door TUI). For a mesh of many servers use [`MeshCa`]
+/// instead — sharing one `InternalMeshKeypair` across N servers means sharing
+/// one private key (no per-server compromise isolation), and generating N of
+/// them forces every client onto an O(N) trust list.
+///
+/// # Example
+///
+/// ```no_run
+/// use unison::network::mesh::InternalMeshKeypair;
+///
+/// let pair = InternalMeshKeypair::generate(
+///     ["broker.local".into(), "*.unison.svc.cluster.local".into()],
+/// )?;
+///
+/// // Server uses `pair.server_cert_source`
+/// // Client uses `pair.client_trust_anchors`
+/// # Ok::<_, anyhow::Error>(())
+/// ```
 pub struct InternalMeshKeypair {
     /// Server-side: feed this into [`crate::network::ProtocolServer`]'s builder.
     pub server_cert_source: CertSource,
@@ -60,5 +77,284 @@ impl InternalMeshKeypair {
             },
             client_trust_anchors: TrustAnchors::Custom(vec![cert_der]),
         })
+    }
+}
+
+/// A private certificate authority for an internal Unison mesh.
+///
+/// Where [`InternalMeshKeypair`] binds one server to its client by a shared
+/// self-signed cert, `MeshCa` scales to many servers: one CA signs a
+/// per-server leaf cert, and every client trusts just the CA.
+///
+/// - **O(1) client trust** — clients hold only the CA cert (via
+///   [`trust_anchors`](Self::trust_anchors)); a new server needs no client
+///   change.
+/// - **per-server keys** — each [`issue`](Self::issue) call mints a fresh leaf
+///   key, so one compromised server does not expose the others.
+/// - **rotation** — re-issue a leaf; the CA is unchanged.
+///
+/// Client-side this needs **no new code**: [`trust_anchors`](Self::trust_anchors)
+/// returns [`TrustAnchors::Custom`], whose `RootCertStore` lets rustls
+/// chain-verify any leaf the CA signed.
+///
+/// The CA is persisted as PEM ([`to_pem`](Self::to_pem) /
+/// [`from_pem`](Self::from_pem)). The CA private key can mint a certificate
+/// for any mesh identity — guard it like any other root secret.
+///
+/// # Example
+///
+/// ```no_run
+/// use unison::network::mesh::MeshCa;
+///
+/// // Control plane: generate once, persist the PEM securely.
+/// let ca = MeshCa::generate()?;
+/// let (ca_cert_pem, ca_key_pem) = ca.to_pem();
+///
+/// // Server side: issue a leaf cert for this server's identity.
+/// let server_cert = ca.issue(["cp.fleetstage.cloud".into()])?;
+///
+/// // Client side: trust just the CA — unchanged as servers come and go.
+/// let client_trust = ca.trust_anchors();
+/// # Ok::<_, anyhow::Error>(())
+/// ```
+pub struct MeshCa {
+    /// Signs leaf certs and carries the CA's distinguished name / key usages.
+    issuer: Issuer<'static, KeyPair>,
+    /// CA cert DER — for client trust anchors and issued-leaf chains.
+    ca_cert_der: CertificateDer<'static>,
+    /// CA cert PEM — retained so [`to_pem`](Self::to_pem) needs no re-encode.
+    ca_cert_pem: String,
+}
+
+impl MeshCa {
+    /// CA certificate validity (days). The CA outlives many leaf rotations.
+    const CA_VALIDITY_DAYS: i64 = 3650;
+    /// Default issued-leaf validity (days). Rotate by re-issuing.
+    const LEAF_VALIDITY_DAYS: i64 = 90;
+
+    /// Generate a fresh mesh CA — a new key plus a self-signed CA certificate.
+    pub fn generate() -> Result<Self> {
+        let mut params = CertificateParams::new(Vec::<String>::new())
+            .context("MeshCa: building CA certificate params")?;
+        // A real CA: BasicConstraints CA:TRUE + keyCertSign so rustls accepts
+        // it as an issuer and chain-verifies leaves against it.
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+            KeyUsagePurpose::DigitalSignature,
+        ];
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Unison Mesh CA");
+        let now = OffsetDateTime::now_utc();
+        params.not_before = now - Duration::hours(1);
+        params.not_after = now + Duration::days(Self::CA_VALIDITY_DAYS);
+
+        let ca_key = KeyPair::generate().context("MeshCa: generating CA key")?;
+        let ca_cert = params
+            .self_signed(&ca_key)
+            .context("MeshCa: self-signing CA certificate")?;
+        let ca_cert_der = ca_cert.der().clone();
+        let ca_cert_pem = ca_cert.pem();
+        let issuer = Issuer::new(params, ca_key);
+
+        Ok(Self {
+            issuer,
+            ca_cert_der,
+            ca_cert_pem,
+        })
+    }
+
+    /// Load a CA previously serialized with [`to_pem`](Self::to_pem).
+    pub fn from_pem(ca_cert_pem: &str, ca_key_pem: &str) -> Result<Self> {
+        let ca_key = KeyPair::from_pem(ca_key_pem).context("MeshCa: parsing CA key PEM")?;
+        let issuer = Issuer::from_ca_cert_pem(ca_cert_pem, ca_key)
+            .context("MeshCa: parsing CA certificate PEM")?;
+        let ca_cert_der = rustls_pemfile::certs(&mut ca_cert_pem.as_bytes())
+            .next()
+            .context("MeshCa: no certificate found in CA PEM")?
+            .context("MeshCa: parsing CA certificate PEM")?;
+
+        Ok(Self {
+            issuer,
+            ca_cert_der,
+            ca_cert_pem: ca_cert_pem.to_string(),
+        })
+    }
+
+    /// Serialize the CA as `(cert PEM, key PEM)` for persistence.
+    ///
+    /// **The key PEM can mint a certificate for any mesh identity** — store it
+    /// with the same care as any root credential (restricted perms, secret
+    /// manager). The cert PEM is public.
+    pub fn to_pem(&self) -> (String, String) {
+        (self.ca_cert_pem.clone(), self.issuer.key().serialize_pem())
+    }
+
+    /// Issue a CA-signed leaf certificate for `sans`, as a server [`CertSource`].
+    ///
+    /// The returned [`CertSource::Provided`] carries the `[leaf, CA]` chain and
+    /// a fresh per-leaf key. A client that trusts this CA (via
+    /// [`trust_anchors`](Self::trust_anchors)) chain-verifies the leaf with no
+    /// extra configuration. Leaf validity defaults to 90 days — rotate by
+    /// re-issuing.
+    pub fn issue(&self, sans: impl IntoIterator<Item = String>) -> Result<CertSource> {
+        let sans: Vec<String> = sans.into_iter().collect();
+        let mut params =
+            CertificateParams::new(sans).context("MeshCa: building leaf certificate params")?;
+        // A leaf, explicitly not a CA. `ServerAuth` EKU is required: under
+        // `TrustAnchors::Custom([ca])` rustls runs its webpki verifier, which
+        // checks the leaf carries the serverAuth extended key usage.
+        params.is_ca = IsCa::ExplicitNoCa;
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        let now = OffsetDateTime::now_utc();
+        params.not_before = now - Duration::hours(1);
+        params.not_after = now + Duration::days(Self::LEAF_VALIDITY_DAYS);
+
+        let leaf_key = KeyPair::generate().context("MeshCa: generating leaf key")?;
+        let leaf_cert = params
+            .signed_by(&leaf_key, &self.issuer)
+            .context("MeshCa: signing leaf certificate")?;
+
+        let leaf_der = leaf_cert.der().clone();
+        let key_der = leaf_key.serialize_der();
+        let private_key = PrivateKeyDer::try_from(key_der)
+            .map_err(|e| anyhow::anyhow!("MeshCa: leaf key parse: {e}"))?;
+        let signing_key = any_supported_type(&private_key)
+            .map_err(|e| anyhow::anyhow!("MeshCa: leaf signing key build: {e}"))?;
+
+        // Present [leaf, CA] as the chain. With `trust_anchors()` the CA is the
+        // client's root; shipping the chain is standard TLS practice.
+        let chain = vec![leaf_der, self.ca_cert_der.clone()];
+        Ok(CertSource::Provided {
+            certified_key: Arc::new(CertifiedKey::new(chain, signing_key)),
+        })
+    }
+
+    /// The client-side trust anchor for this CA — `Custom([CA cert])`.
+    ///
+    /// Every client in the mesh uses this; it does **not** change when servers
+    /// are added or their leaf certs rotate.
+    pub fn trust_anchors(&self) -> TrustAnchors {
+        TrustAnchors::Custom(vec![self.ca_cert_der.clone()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rustls::RootCertStore;
+    use rustls::client::WebPkiServerVerifier;
+    use rustls::client::danger::ServerCertVerifier;
+    use rustls::pki_types::{ServerName, UnixTime};
+
+    use super::*;
+
+    /// `issue()` が返す `CertSource::Provided` から `[leaf, ca]` チェーンを取り出す。
+    fn chain_of(src: &CertSource) -> Vec<CertificateDer<'static>> {
+        match src {
+            CertSource::Provided { certified_key } => certified_key.cert.clone(),
+            _ => panic!("MeshCa::issue must return CertSource::Provided"),
+        }
+    }
+
+    /// `MeshCa` の CA cert を 1 つだけ含む `RootCertStore` から検証器を作る。
+    fn verifier_trusting(ca: &MeshCa) -> Arc<WebPkiServerVerifier> {
+        let TrustAnchors::Custom(ca_certs) = ca.trust_anchors() else {
+            panic!("trust_anchors() must be Custom");
+        };
+        let mut roots = RootCertStore::empty();
+        roots.add(ca_certs[0].clone()).expect("add CA to root store");
+        WebPkiServerVerifier::builder_with_provider(
+            Arc::new(roots),
+            Arc::new(rustls::crypto::ring::default_provider()),
+        )
+        .build()
+        .expect("build WebPkiServerVerifier")
+    }
+
+    #[test]
+    fn generate_succeeds() {
+        MeshCa::generate().expect("MeshCa::generate");
+    }
+
+    #[test]
+    fn pem_roundtrip_preserves_the_ca() {
+        let ca = MeshCa::generate().unwrap();
+        let (cert_pem, key_pem) = ca.to_pem();
+        let reloaded = MeshCa::from_pem(&cert_pem, &key_pem).expect("from_pem");
+
+        let TrustAnchors::Custom(orig) = ca.trust_anchors() else { unreachable!() };
+        let TrustAnchors::Custom(back) = reloaded.trust_anchors() else { unreachable!() };
+        assert_eq!(orig, back, "reloaded CA must point at the same cert");
+    }
+
+    #[test]
+    fn issue_returns_a_leaf_ca_chain() {
+        let ca = MeshCa::generate().unwrap();
+        let chain = chain_of(&ca.issue(["leaf.test".to_string()]).expect("issue"));
+
+        assert_eq!(chain.len(), 2, "chain should be [leaf, ca]");
+        let TrustAnchors::Custom(ca_certs) = ca.trust_anchors() else { unreachable!() };
+        assert_eq!(chain[1], ca_certs[0], "chain[1] must be the CA cert");
+    }
+
+    #[test]
+    fn issued_leaf_verifies_against_its_ca() {
+        let ca = MeshCa::generate().unwrap();
+        let chain = chain_of(&ca.issue(["leaf.test".to_string()]).unwrap());
+        let verifier = verifier_trusting(&ca);
+
+        verifier
+            .verify_server_cert(
+                &chain[0],
+                &chain[1..],
+                &ServerName::try_from("leaf.test").unwrap(),
+                &[],
+                UnixTime::now(),
+            )
+            .expect("a CA-signed leaf must verify against that CA's trust anchor");
+    }
+
+    #[test]
+    fn leaf_is_rejected_by_an_unrelated_ca() {
+        let ca_a = MeshCa::generate().unwrap();
+        let ca_b = MeshCa::generate().unwrap();
+        let chain = chain_of(&ca_a.issue(["leaf.test".to_string()]).unwrap());
+
+        // CA-B の trust anchor で CA-A 発行の leaf を検証 → 失敗するはず。
+        let result = verifier_trusting(&ca_b).verify_server_cert(
+            &chain[0],
+            &chain[1..],
+            &ServerName::try_from("leaf.test").unwrap(),
+            &[],
+            UnixTime::now(),
+        );
+        assert!(
+            result.is_err(),
+            "a leaf signed by an unrelated CA must not verify"
+        );
+    }
+
+    #[test]
+    fn reloaded_ca_still_issues_verifiable_leaves() {
+        let ca = MeshCa::generate().unwrap();
+        let (cert_pem, key_pem) = ca.to_pem();
+        let reloaded = MeshCa::from_pem(&cert_pem, &key_pem).unwrap();
+
+        // from_pem 後の CA が発行した leaf も、元 CA の trust anchor で検証できる。
+        let chain = chain_of(&reloaded.issue(["leaf.test".to_string()]).unwrap());
+        verifier_trusting(&ca)
+            .verify_server_cert(
+                &chain[0],
+                &chain[1..],
+                &ServerName::try_from("leaf.test").unwrap(),
+                &[],
+                UnixTime::now(),
+            )
+            .expect("leaf from a reloaded CA must verify against the original trust anchor");
     }
 }

--- a/crates/unison-protocol/src/network/mod.rs
+++ b/crates/unison-protocol/src/network/mod.rs
@@ -29,7 +29,7 @@ pub use channel::UnisonChannel;
 pub use client::{ClientConnectionEvent, ClientConnectionEventReceiver, ProtocolClient};
 pub use conn::UnisonConn;
 pub use datagram_channel::DatagramChannel;
-pub use mesh::InternalMeshKeypair;
+pub use mesh::{InternalMeshKeypair, MeshCa};
 pub use quic::{QuicClient, QuicServer, TypedFrame, UnisonStream};
 pub use server::{ConnectionEvent, ConnectionEventReceiver, ProtocolServer, ServerHandle};
 pub use trust::TrustAnchors;

--- a/crates/unison-protocol/src/network/trust.rs
+++ b/crates/unison-protocol/src/network/trust.rs
@@ -11,7 +11,8 @@
 //! | Scenario | Variant |
 //! |----------|---------|
 //! | Connect to public server (CA chain) | [`TrustAnchors::System`] |
-//! | Internal mesh (pinned CA) | [`TrustAnchors::Custom`] (via [`super::mesh::InternalMeshKeypair`]) |
+//! | Internal mesh, fixed pair | [`TrustAnchors::Custom`] (via [`super::mesh::InternalMeshKeypair`]) |
+//! | Internal mesh, many servers (private CA) | [`TrustAnchors::Custom`] (via [`super::mesh::MeshCa::trust_anchors`]) |
 //! | Dev against `dev_localhost()` server | [`TrustAnchors::SkipVerification`] |
 
 use std::sync::Arc;


### PR DESCRIPTION
## 概要

fleetflow lead からの dogfood handoff（wire msg `019e4f61`、設計合意 reply `019e4f6a`）を受け、内部 mesh 用の private 認証局 **`network::mesh::MeshCa`** を新設する。

fleetflow の Podman+Quadlet 移行 epic が unison rc.1 の trust モデルでブロック中だった: 非 loopback の CP ↔ agent/CLI/MCP の QUIC 接続で、公開 CA 無し・複数 server・per-server trust 設定回避という条件を満たす primitive が無かった。

## API

```rust
MeshCa::generate()          // CA cert+key を生成
MeshCa::from_pem(cert, key) // 永続化からロード
MeshCa::to_pem()            // CA cert+key を PEM 化
MeshCa::issue(sans)         // CA 署名 leaf を CertSource として発行
MeshCa::trust_anchors()     // client 用 TrustAnchors::Custom([CA])
```

## 設計ポイント

- **client 側は新規コード不要** — `TrustAnchors::Custom` は `RootCertStore::add()` 経由で rustls の chain 検証に乗る。CA cert を `Custom` に入れれば leaf は自動 chain 検証され、新 `TrustAnchors` variant も verifier 改修も不要
- **`InternalMeshKeypair` のスケール問題を解消** — self-signed 1 枚の pairwise は N server で「鍵共有（compromise 隔離なし）」か「`Custom([N 枚])`（O(N)）」になる。`MeshCa` は client が CA 1 枚を信頼するだけ（O(1)）、server 追加で client 無改修、per-server key で隔離
- CA cert は `BasicConstraints:CA:TRUE` + `keyCertSign`、leaf は `ServerAuth` EKU + `[leaf, ca]` chain で発行
- `from_pem` のため `rcgen` の `x509-parser` feature を有効化

## v1 スコープ

`CertSource::Provided`（raw QUIC 向け）で発行。fleetflow lead 確認済み: agent/CLI/MCP↔CP は WebTransport ingress 無しのため v1 はこれで確定。CRL/OCSP 失効・TOFU 層は後回し（v1 は短寿命 leaf=90日 + reissue で代替）。

## テスト（6 件、全 pass）

rustls の `WebPkiServerVerifier` で**実際の chain 検証**まで確認:

- `issued_leaf_verifies_against_its_ca` — CA 署名 leaf が CA trust anchor で検証成功
- `leaf_is_rejected_by_an_unrelated_ca` — 無関係 CA の leaf は拒否（negative）
- `reloaded_ca_still_issues_verifiable_leaves` — `from_pem` 後の CA が発行した leaf も検証成功
- `pem_roundtrip_preserves_the_ca` / `issue_returns_a_leaf_ca_chain` / `generate_succeeds`

`cargo clippy --lib` clean。

handoff の経緯は creo-memories `mem_1CbHXGYzZSK4cwGYj4TBFi`（unison Atlas、status: active）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)