### PR TITLE
docs(readme): rc.3 に同期 — MeshCa 追記 + 依存バージョン更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ KDL スキーマベースの型安全な QUIC 通信フレームワーク。
 ```toml
 [dependencies]
 # crates.io package = `club-unison`、Rust crate identifier = `unison`
-club-unison = "^0.10"
+club-unison = "1.0.0-rc.3"
 tokio = { version = "1.52", features = ["full"] }
 ```
 
@@ -23,14 +23,19 @@ let server_config = QuicServer::configure_server_with(CertSource::dev_localhost(
 // Client: trust anchor も TrustAnchors enum で明示選択
 let client_config = QuicClient::configure_client_with(TrustAnchors::System).await?;
 
-// 内部メッシュ: 両端を 1 つの pair で生成
+// 内部メッシュ (固定ペア): 両端を 1 つの pair で生成
 use unison::network::InternalMeshKeypair;
 let pair = InternalMeshKeypair::generate(["broker.local".into(), "*.unison.local".into()])?;
-// pair.server_cert_source → server 側
-// pair.client_trust_anchors → client 側
+// pair.server_cert_source → server 側 / pair.client_trust_anchors → client 側
+
+// 内部メッシュ (多 server): private CA で per-server cert を発行
+use unison::network::MeshCa;
+let ca = MeshCa::generate()?;
+let server_cert = ca.issue(["cp.internal".into()])?; // server 側 CertSource
+let client_trust = ca.trust_anchors();               // 全 client 共通 (CA 1 枚を信頼)
 ```
 
-詳細な trust model 設計は [CHANGELOG](https://github.com/chronista-club/club-unison/blob/main/CHANGELOG.md) の v0.7.0 (TLS 導入) と v0.9.0 (deprecated `configure_*()` 削除) entry を参照。
+詳細な trust model 設計は [CHANGELOG](https://github.com/chronista-club/club-unison/blob/main/CHANGELOG.md) の v0.7.0 (TLS 導入) / v0.9.0 (deprecated `configure_*()` 削除) / v1.0.0-rc.3 (`MeshCa` private CA) entry を参照。
 
 ---
 


### PR DESCRIPTION
## 概要

`club-unison 1.0.0-rc.3` リリースに合わせた README 同期（Living Documentation）。

- 依存例 `club-unison = "^0.10"` → `"1.0.0-rc.3"`（stale だった）
- 内部メッシュの例に `MeshCa`（多 server 向け private CA）を追記。既存 `InternalMeshKeypair` は「固定ペア」と明示し、2 つの使い分けが README から読める状態に
- trust model 設計参照に `v1.0.0-rc.3`（`MeshCa`）entry を追加

`design/`/`guides/`/`spec/` には trust モデルの記述が元々無く（コード doc-comment と CHANGELOG が SSOT）、`guides/integration-guide.md` の `1.0.0-rc.1` は npm `@chronista-club/unison-client`（別アーティファクト、実際 rc.1 のまま）なので sync 対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)