### PR TITLE
docs: IPv4 / IPv6 両対応を明示（誤記訂正）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ## [Unreleased]
 
+### 修正 — IPv4 / IPv6 両対応を明示（誤記訂正）
+
+実装は当初から IPv4 / IPv6 両家族に対応していた（`network::quic::resolve_socket_addr` が両者を受理し、client は target family に合わせて local bind を切り替え、`server.rs` の bind テストも `127.0.0.1` 使用）が、README が「IPv6 専用設計」と誤って明言していたため訂正:
+
+- `README.md` 「IPv6 専用設計」→ 「IPv4 / IPv6 どちらでも繋がる」（bare port → `::1` フォールバックのバイアスは明記）
+- `unison` CLI の `ping` / `sniff` / `call` arg help に `quic://127.0.0.1:7878` の IPv4 例を併記
+- `spec/01-core-concept/SPEC.md` シーケンス図の note を「IPv6 アドレス解析」→「IPv4 / IPv6 アドレス解析」、`Endpoint::client` を family-matched bind 表記に
+
+コード変更なし。
+
 ## [1.0.0-rc.4] - 2026-05-23 — crates.io readme refresh + README clone fix
 
 > rc.3 と同じコードのまま、**crates.io 上の readme を同期するための republish**。

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ cargo build
 RUSTFLAGS="-C symbol-mangling-version=v0" cargo test --workspace
 ```
 
-IPv6 専用設計。アドレスは `[::1]:port` を使う。
+**IPv4 / IPv6 どちらでも繋がる。** `[::1]:port`（IPv6 ループバック）でも `127.0.0.1:port`（IPv4 ループバック）でも、ホスト名（DNS 解決）でも OK。client は target アドレスの family に合わせて local bind を切り替える。CLI 既定と多くの例は IPv6 寄りで、bare port のみ（`8080` 等）指定した場合は `[::1]` にフォールバックする。
 
 ## ドキュメント
 

--- a/crates/unison-cli/src/call.rs
+++ b/crates/unison-cli/src/call.rs
@@ -17,7 +17,7 @@ use crate::TrustMode;
 
 #[derive(Args)]
 pub struct CallArgs {
-    /// Unison サーバの URL (例: `quic://[::1]:7878`)
+    /// Unison サーバの URL (例: `quic://[::1]:7878` / `quic://127.0.0.1:7878`)
     pub url: String,
 
     /// request を送る channel 名

--- a/crates/unison-cli/src/ping.rs
+++ b/crates/unison-cli/src/ping.rs
@@ -14,7 +14,7 @@ use crate::TrustMode;
 
 #[derive(Args)]
 pub struct PingArgs {
-    /// Unison サーバの URL (例: `quic://[::1]:7878`)
+    /// Unison サーバの URL (例: `quic://[::1]:7878` / `quic://127.0.0.1:7878`)
     pub url: String,
 
     /// trust anchor mode (default: skip — dev self-signed 用)

--- a/crates/unison-cli/src/sniff.rs
+++ b/crates/unison-cli/src/sniff.rs
@@ -18,7 +18,7 @@ use crate::TrustMode;
 
 #[derive(Args)]
 pub struct SniffArgs {
-    /// Unison サーバの URL (例: `quic://[::1]:7878`)
+    /// Unison サーバの URL (例: `quic://[::1]:7878` / `quic://127.0.0.1:7878`)
     pub url: String,
 
     /// 覗く channel 名

--- a/spec/01-core-concept/SPEC.md
+++ b/spec/01-core-concept/SPEC.md
@@ -328,8 +328,8 @@ sequenceDiagram
     participant C as QuicClient
     participant S as QuicServer
 
-    Note over C: IPv6 アドレス解析
-    C->>C: Endpoint::client("[::]:0")
+    Note over C: IPv4 / IPv6 アドレス解析
+    C->>C: Endpoint::client(family-matched bind: "0.0.0.0:0" or "[::]:0")
     C->>S: QUIC 接続要求
     Note over C,S: TLS 1.3 ハンドシェイク
     S-->>C: 接続確立


### PR DESCRIPTION
## 概要

README の「IPv6 専用設計」という記述が**実装と矛盾**していたため訂正する。

実装は当初から IPv4 / IPv6 両家族に対応していた:

- `network::quic::resolve_socket_addr` が IPv4 / IPv6 リテラル両方を受理（doc も「IPv6 / IPv4 リテラル + DNS hostname を受け付け」と明記）
- client の local bind は target family に合わせて切り替え: `SocketAddr::V4 → 0.0.0.0:0`、`V6 → [::]:0`（`quic.rs:320-323`）
- `server.rs` の bind テスト 6 件（`server.rs:626/647/693/717/739/760`）はそもそも `127.0.0.1:NNNN` で動いていた — テストが期せず IPv4 対応の事実上の証明になっていた
- `unison mock --addr 127.0.0.1:7878` + `unison ping`/`unison call` で QUIC handshake / channel open / request response が IPv4 で完走することを今回実走確認

ところが README l.239 が「IPv6 専用設計。アドレスは `[::1]:port` を使う。」と誤明言していたため、IPv4-only 環境のユーザに「使えない」と誤解させる可能性があった。

## 変更（コード変更なし、ドキュメント / コメントのみ）

- `README.md` 「IPv6 専用設計」を「IPv4 / IPv6 どちらでも繋がる」に書き換え。bare port → `::1` フォールバックという IPv6 バイアスは明記（隠さず正直に）
- `unison` CLI の `ping` / `sniff` / `call` の arg help に `quic://127.0.0.1:7878` の IPv4 例を併記
- `spec/01-core-concept/SPEC.md` シーケンス図の Note を「IPv6 アドレス解析」→「IPv4 / IPv6 アドレス解析」、`Endpoint::client(...)` を family-matched bind 表記に
- `CHANGELOG` `[Unreleased]` に記録

## 補足

crates.io 上の readme は publish 時固定なので、本 PR を取り込んでも rc.4 の readme は古いまま。次の publish（rc.5 or 1.0.0）で同期される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)