### PR TITLE
chore(release): 1.0.0-rc.5 — IPv4/IPv6 文書訂正 + crates.io readme refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.5] - 2026-05-23 — IPv4 / IPv6 両対応の文書訂正 + crates.io readme refresh
+
+> rc.4 と同じコードのまま、IPv4 / IPv6 両対応を明示するドキュメント訂正を反映した
+> readme で再 publish。rc.4 publish 時点では README が「IPv6 専用設計」と誤明言
+> しており、crates.io 上の readme もその古い記述で焼かれていた。
+
 ### 修正 — IPv4 / IPv6 両対応を明示（誤記訂正）
 
 実装は当初から IPv4 / IPv6 両家族に対応していた（`network::quic::resolve_socket_addr` が両者を受理し、client は target family に合わせて local bind を切り替え、`server.rs` の bind テストも `127.0.0.1` 使用）が、README が「IPv6 専用設計」と誤って明言していたため訂正:
@@ -15,7 +21,7 @@
 - `unison` CLI の `ping` / `sniff` / `call` arg help に `quic://127.0.0.1:7878` の IPv4 例を併記
 - `spec/01-core-concept/SPEC.md` シーケンス図の note を「IPv6 アドレス解析」→「IPv4 / IPv6 アドレス解析」、`Endpoint::client` を family-matched bind 表記に
 
-コード変更なし。
+ライブラリの API・実装は **rc.4 と同一**（README/SPEC/CLI doc-comment / version メタデータのみ）。
 
 ## [1.0.0-rc.4] - 2026-05-23 — crates.io readme refresh + README clone fix
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ KDL スキーマベースの型安全な QUIC 通信フレームワーク。
 ```toml
 [dependencies]
 # crates.io package = `club-unison`、Rust crate identifier = `unison`
-club-unison = "1.0.0-rc.4"
+club-unison = "1.0.0-rc.5"
 tokio = { version = "1.52", features = ["full"] }
 ```
 


### PR DESCRIPTION
## 概要

rc.4 と同じコードのまま `1.0.0-rc.5` を publish し、crates.io 上の readme を **PR #59（IPv4/IPv6 両対応の文書訂正）反映版**で同期する。

rc.4 publish 時点（commit `390e7bd`）では README が「IPv6 専用設計」と誤明言しており、crates.io 上の readme もその古い記述で焼かれていた。crates.io は publish 時点の readme を永続焼き込みのため、新規 version の publish が必要。

## 変更

- `Cargo.toml`: workspace version `1.0.0-rc.4` → `1.0.0-rc.5`
- `README.md`: install pin `"1.0.0-rc.4"` → `"1.0.0-rc.5"`
- `CHANGELOG.md`: `[Unreleased]` を `[1.0.0-rc.5]` セクションに繰り上げ

ライブラリの API・実装は **rc.4 と同一**（README/SPEC/CLI doc-comment と version メタデータのみ）。

## マージ後

`cargo publish -p club-unison` → `v1.0.0-rc.5` tag。crates.io 上の readme が「IPv4 / IPv6 どちらでも繋がる」表記で焼き直される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)