### PR TITLE
chore(release): 1.0.0 GA — protocol API freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-23 — v1.0 GA: protocol API freeze
+
+> v1.0 sprint の到達点。`alpha.1` → `alpha.2` → `rc.1` 〜 `rc.5` で固めた内容を
+> そのまま stable に昇格し、**SemVer の stability commitment** に入る。
+> これ以降の minor / patch リリースは API 互換を保つ。破壊的変更が必要な
+> 場合は v2.0。
+
+### API freeze 対象（SemVer 互換の保証範囲）
+
+- `unison::{ProtocolClient, ProtocolServer, UnisonChannel, ServerHandle}` の public API
+- `network::trust::{TrustAnchors, ...}` および `network::cert::{CertSource, ...}` の trust 抽象
+- `network::mesh::{InternalMeshKeypair, MeshCa}` の internal mesh primitive
+- `network::quic::{QuicClient, QuicServer, UnisonStream, TypedFrame}`
+- `codec::{JsonCodec, ProtoCodec, Codec, Encodable, Decodable}`
+- `wire` の proto3 `ProtocolMessage` フォーマット（同一 wire 形式互換）
+- KDL channel schema 構文（`channel` / `request` / `returns` / `event` / `field`）
+
+### コード
+
+rc.5 と**同一バイナリ**（version メタデータと CHANGELOG のみ変更）。crates.io 上で stable として認識され、`/crates/club-unison` の landing が v1.0.0 になる。
+
+### v0.x → v1.0 累積（rc.1 entry の要約）
+
+- Polyglot client base: Rust core + TS SDK + Ruby gem
+- Unified Channel: request/response + event push + Datagram、JsonCodec / ProtoCodec
+- WebTransport ingress（browser ↔ Rust server）
+- MeshCa private-CA primitive（rc.3〜）— IPv4 / IPv6 両対応
+- `unison` CLI: `ping` / `sniff` / `mock` / `call` / `schema-lint`
+- dogfood signal: fleetflow handoff (MeshCa) / VP dashboard 統合 / Ruby client E2E + bench
+
 ## [1.0.0-rc.5] - 2026-05-23 — IPv4 / IPv6 両対応の文書訂正 + crates.io readme refresh
 
 > rc.4 と同じコードのまま、IPv4 / IPv6 両対応を明示するドキュメント訂正を反映した

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0-rc.5"
+version = "1.0.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ KDL スキーマベースの型安全な QUIC 通信フレームワーク。
 ```toml
 [dependencies]
 # crates.io package = `club-unison`、Rust crate identifier = `unison`
-club-unison = "1.0.0-rc.5"
+club-unison = "1.0.0"
 tokio = { version = "1.52", features = ["full"] }
 ```
 


### PR DESCRIPTION
## 概要

club-unison **v1.0 GA**。`alpha.1` → `alpha.2` → `rc.1` 〜 `rc.5` で固めた内容をそのまま stable に昇格し、**SemVer の stability commitment** に入る。これ以降の minor / patch リリースは API 互換を保つ。破壊的変更が必要な場合は v2.0。

## 変更

- `Cargo.toml` workspace version: `1.0.0-rc.5` → `1.0.0`
- `README.md` install pin: `"1.0.0-rc.5"` → `"1.0.0"`
- `CHANGELOG.md`: `[1.0.0]` GA セクション追加（API freeze 対象を明記）

**ライブラリの API・実装は rc.5 と同一**（version メタデータと CHANGELOG のみ）。

## API freeze 対象（SemVer 互換の保証範囲）

- `unison::{ProtocolClient, ProtocolServer, UnisonChannel, ServerHandle}`
- `network::trust::{TrustAnchors, ...}` / `network::cert::{CertSource, ...}`
- `network::mesh::{InternalMeshKeypair, MeshCa}`
- `network::quic::{QuicClient, QuicServer, UnisonStream, TypedFrame}`
- `codec::{JsonCodec, ProtoCodec, Codec, Encodable, Decodable}`
- `wire` の proto3 `ProtocolMessage` フォーマット
- KDL channel schema 構文

## マージ後

`cargo publish -p club-unison` → `v1.0.0` tag → GitHub release（milestone）。crates.io 上で `1.0.0` が最新 stable になり、`/crates/club-unison` の landing が `v0.10.1` から `v1.0.0` に切り替わる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)