### PR TITLE
docs(dogfood): VP dogfood session 1 — 3 signal handoff + datagram codegen 記述 update

### DIFF
--- a/clients/typescript/examples/vp-dashboard.ts
+++ b/clients/typescript/examples/vp-dashboard.ts
@@ -21,7 +21,12 @@ import { StreamServerStub, sendIdentity } from "../tests/integration/server_stub
 import type { BidiStream } from "../src/transport/types.js";
 
 // ============================================================
-// Channel meta (= Phase 1 codegen 出力の代用、 vp-dashboard KDL schema 由来)
+// Channel meta (= 教材用の手書き、 codegen 範を理解するための reference)
+//
+// `club-kdl-codegen 0.9.0` 以降は stream / datagram どちらも生成可能になっており
+// （VP dogfood で確認、 dogfood/vp-2026-05-26.md signal #2）、 実 use では
+// 手書きせず codegen で吐く方を推奨する。 ここは「codegen が出すべき形」 を読者が
+// 理解するための self-contained 例として残す。
 //
 // 生成 interface + `__types` phantom carrier 込みで書く (= codegen が吐く
 // `<Channel>ChannelEventTypes` / `<Channel>ChannelRequestTypes` + meta `__types`

--- a/dogfood/vp-2026-05-26.md
+++ b/dogfood/vp-2026-05-26.md
@@ -1,0 +1,190 @@
+# VP dogfood — session 1 (2026-05-26)
+
+> **from**: vantage-point lead (mako) / **to**: club-unison lead
+> **format**: signal report (= codegen 修正は別 repo handoff)
+> **dogfood handoff parent**: creo-memories `mem_1Cb6sMLFXDi8xgrWriPzaE` (= 2026-05-17 club-unison → VP handoff)
+> **VP 側 dev journal**: creo-memories `mem_1CbPm6RtoPEGnR5cchc8qW`
+
+VP dashboard を `@chronista-club/unison-client@1.0.0-rc.1` で組み始めた最初の session の dogfood feedback。 3 signal を crystallize したので詳細 + next action proposal を以下に記録する。 本 PR では合わせて signal #2 関連の docs update も同時 land する (= guides + example コメント)。
+
+## TL;DR
+
+| done | how |
+|---|---|
+| Rust crate `club-unison v1.0.0-rc.1 → v1.0.0` GA bump | VP `Cargo.toml`、 `cargo check -p vantage-point` 31.58s clean (= API freeze の効力、 既存コード破壊ゼロ) |
+| 範 example smoke (`npm run example`) | 3 channel + lifecycle 全動作確認 ✅ |
+| VP `crates/vp-app/schema/vp-dashboard.kdl` schema 設計 | 3 channel (metric datagram + lane_status stream event + control stream request) |
+| `cargo test -p vp-app --test dashboard_codegen` 経由で codegen | 生成物 `dashboard.rs` (4 struct) + `Dashboard.ts` (3 ChannelMeta + 5 interface) ✅ |
+| caller code draft (= range PART A の generated import 版) | type 6 件 error ← **production blocker (signal #3)** |
+
+## Signal #1 — 範 paste path で 6 file copy 要 (suggestion)
+
+範 `clients/typescript/examples/vp-dashboard.ts` を別 repo に移植しようとすると 6 file の source copy が必要:
+
+| file | location | reason |
+|---|---|---|
+| `mock_transport.ts` | `tests/integration/` | npm `files` 配布外 (= test fixture) |
+| `server_stub.ts` | `tests/integration/` | 同上 |
+| `vp-dashboard.ts` | `examples/` | npm 配布外 |
+| `async_queue.ts` (`AsyncQueue`) | `src/channel/` | **`dist/index.d.ts` re-export に無し** (= internal util) |
+| `varint.ts` (`encodeVarint`) | `src/channel/` | 同上 |
+| `frame.ts` の `readFrames` | `src/channel/` | `decodeTypedFrame` / `encodeProtocolFrame` は public、 `readFrames` だけ漏れ |
+
+### proposal
+
+1. **mock harness を公式 export**: `@chronista-club/unison-client/testing` subpath (= `package.json` の `exports` field) で `MockTransport` / `StreamServerStub` / `sendIdentity` / `TEST_IDENTITY` を配布。 dogfood 開始の friction が「npm install + import 1 行」 に圧縮される
+2. **internal util を public re-export**: `AsyncQueue` / `encodeVarint` / `readFrames` を `index.d.ts` に追加。 範を写経しようとした dev が internal を copy する誘惑を消す
+3. **examples を npm package or docs site で viewable に**: 現状 `files: ["dist", "README.md", "LICENSE"]` で example も npm 配布外、 docs site の embed か別 subpath か discussion ありそう
+
+## Signal #2 — datagram channel の TS codegen は **既に動く** (comment)
+
+handoff memo (2026-05-17 rc.1 段階):
+
+> datagram channel の TS codegen 未対応 → datagram の `ChannelMeta` は手書き（`examples/vp-dashboard.ts` が範）
+
+これは **outdated**。 `club-kdl-codegen 0.9.0` で datagram channel を含む schema を codegen したところ、 datagram 専用 field `channelId` まで含めて完璧に生成された:
+
+```ts
+export const MetricChannelMeta = {
+  name: "metric" as const,
+  backend: "datagram" as const,
+  channelId: 1 as const,                    // ← datagram-only field、生成済 ✅
+  from: "server" as const,
+  lifetime: "persistent" as const,
+  events: ["MetricUpdate"] as const,
+  requests: {} as const,
+  __types: undefined as unknown as { events: MetricChannelEventTypes; requests: MetricChannelRequestTypes },
+} as const;
+```
+
+範 example 手書き形 (= `as const satisfies DatagramChannelMeta` + `__types`) と **1:1 同型**。 production では codegen 経由が望ましく、 手書きは教材意義のみ。
+
+### proposal — 本 PR で同時 land
+
+- `guides/integration-guide.md` §3③ の rc 段階制約 (= datagram TS codegen 未対応) 記述を撤回
+- `clients/typescript/examples/vp-dashboard.ts` 冒頭の Channel meta コメント (= 「Phase 1 codegen 出力の代用」) を「教材用の手書き、 実 use では codegen 経由」 に整理
+
+## Signal #3 — codegen `interface` ⇏ SDK `Record` で **production blocker** (concern)
+
+`club-kdl-codegen 0.9.0` は以下を生成:
+
+```ts
+export interface ControlChannelRequestTypes {
+  SubscribeMetric: { request: SubscribeMetric; response: Subscribed };
+}
+```
+
+一方、 SDK rc.1 の `ChannelMeta` 型 (`dist/channel/types.d.ts`):
+
+```ts
+type ChannelMeta = {
+  __types: {
+    events: Readonly<Record<string, unknown>>;
+    requests: Readonly<Record<string, { request: unknown; response: unknown }>>;
+  };
+};
+```
+
+### 何が起きるか
+
+TS の structural typing で **`interface` は明示 property のみで `Record<string, X>` の open index signature を持たない** → caller が `client.openChannel(ControlChannelMeta)` を呼ぶと 6 件の compile error:
+
+```text
+✘ Type 'ControlChannelRequestTypes' is not assignable to type
+  'Readonly<Record<string, { request: unknown; response: unknown }>>'.
+  Index signature for type 'string' is missing in type 'ControlChannelRequestTypes'.
+
+✘ Type 'unknown' is not assignable to type 'Subscribed'.
+```
+
+production code を type-safe に書く道が **塞がる** — cast escape `as unknown as ChannelMeta` でしか抜け道なく、 caller 側 type narrowing (= `request("SubscribeMetric", ...)` が `Subscribed` に narrow される) も失われる。
+
+### なぜ club-unison repo 内 では顕在化しなかったか
+
+club-unison repo 内の TS SDK tests (= `tests/integration/`) は `MockTransport` 経由で `ChannelMeta` を SDK 側 type と直接 narrow させていない (= 内部 implementation が型を取り出す)。 VP 側 caller (= 外部から SDK を呼ぶ form) で初めて contact、 type incompatibility が surface。
+
+### proposal — codegen 側 fix
+
+codegen を以下のいずれかに修正:
+
+**option 1 (推奨): `type alias` を出力** — caller の型 narrowing 維持 + SDK 側変更不要
+
+```ts
+export type ControlChannelRequestTypes = {
+  SubscribeMetric: { request: SubscribeMetric; response: Subscribed };
+};
+```
+
+structural typing 上 `Record<string, X>` と互換、 既存生成 form (= ChannelEventTypes / ChannelRequestTypes 両方) を同様に `type` に変えるだけ。 caller 側 `request("SubscribeMetric", ...)` の `Subscribed` への narrowing も維持。
+
+**option 2: interface に index signature を明示** — type-safety を犠牲
+
+```ts
+export interface ControlChannelRequestTypes {
+  [K: string]: { request: unknown; response: unknown };
+  SubscribeMetric: { request: SubscribeMetric; response: Subscribed };
+}
+```
+
+dubious (= unknown 名 lookup が許容され、 caller の typo を catch しなくなる)。
+
+**option 3: SDK 側 constraint を緩める**
+
+```ts
+type ChannelMeta<Reqs extends Record<string, { request: unknown; response: unknown }> = Record<string, never>> = {
+  __types: { events: Record<string, unknown>; requests: Reqs };
+};
+```
+
+generic param で受ける形。 codegen + SDK 両 fix 要、 影響範囲広い。
+
+### codegen は別 repo
+
+`club-kdl-codegen` は本 repo (club-unison) の workspace 内に無く、 別 repo or crates.io publish のみ。 本 fix PR は別 repo handoff となる予定 (= 本 PR は signal 報告 first step)。
+
+## VP 側 verify trail (= reproducer 用)
+
+```
+~/repos/vantage-point/
+├── Cargo.toml                                              # unison version "1.0.0" に bump 済
+├── crates/vp-app/schema/vp-dashboard.kdl                   # 3 channel schema (新規)
+├── crates/vp-app/tests/dashboard_codegen.rs                # codegen test (新規、 sidebar_ipc_codegen 同型)
+├── crates/vp-app/src/generated/dashboard.rs                # 生成 Rust (4 struct)
+└── crates/vp-app/web-bundle/
+    ├── package.json                                        # @chronista-club/unison-client@1.0.0-rc.1 install 済
+    └── src/
+        ├── generated/Dashboard.ts                          # 生成 TS (3 ChannelMeta + 5 interface)
+        └── dashboard/index.ts                              # caller code draft (= signal #3 で type error)
+```
+
+```bash
+# 再現:
+$ cd ~/repos/vantage-point && cargo test -p vp-app --test dashboard_codegen
+# ✅ PASS、 生成物 idempotent
+
+$ cd crates/vp-app/web-bundle && bun run build
+# ✘ tsc 6 件 type error (= signal #3)
+```
+
+## next action map
+
+| signal | action | location | 本 PR で対応? |
+|---|---|---|---|
+| #1 | `/testing` subpath publish + util public re-export | club-unison TS SDK | ❌ 別 PR |
+| #2 | `guides/integration-guide.md` §3③ + `examples/vp-dashboard.ts` コメント update | club-unison docs | ✅ 同 PR で land |
+| #3 | codegen `interface` → `type alias` 化 | **club-kdl-codegen repo** | ❌ 別 repo handoff |
+
+## chain (= memory references)
+
+- VP 側 dev journal (= 本 session の総括): creo-memories `mem_1CbPm6RtoPEGnR5cchc8qW`
+- signal annotations on handoff parent (= 詳細個別):
+  - #1 suggestion: `mem_1CbPchg7FaWEQdi9tHj55B`
+  - #2 comment: `mem_1CbPgMX9eiZ6uJ1ZvzkaDR`
+  - #3 concern: `mem_1CbPjGqZ9FVGnoQY8c5SWh`
+- dogfood handoff parent (= 2026-05-17 club-unison → VP): `mem_1Cb6sMLFXDi8xgrWriPzaE`
+- dogfood todo (= VP atlas 棚卸し NOW #1): `mem_1Cb6sMca3qkNSvsMTthics`
+- VP atlas 棚卸し session (= NOW #1 確定の元): `mem_1CbNyecHuWWAySrXLMpfNN`
+
+---
+
+**注**: 本 doc は dogfood の cross-project handoff record として repo に置く第 1 個目の form。 後続 dogfood session の signal が増えたら `dogfood/<source>/<date>.md` 形式に整理する想定 (= convention は first use で確立)。

--- a/guides/integration-guide.md
+++ b/guides/integration-guide.md
@@ -164,10 +164,11 @@ Unison は **KDL スキーマが型の SSOT**。コード生成は `club-kdl-cod
 - `as const` の `ChannelMeta`（`__types` phantom carrier 込み — これにより
   `events()` / `request()` が生成 interface に型 narrow される）
 
-> **rc 段階の制約**: v1.0 の codegen は **stream channel まで**。datagram channel の
-> TS codegen は v1.x deferred のため、datagram の `ChannelMeta` は当面**手書き**する。
-> 手書きの形は [`vp-dashboard.ts` example](../clients/typescript/examples/vp-dashboard.ts)
-> がそのまま範になる（`as const satisfies DatagramChannelMeta` + `__types`）。
+> **codegen の対応範囲**: `club-kdl-codegen 0.9.0` で stream channel + datagram channel
+> どちらも codegen 動く。 datagram channel は専用 field `channelId` も含めて完璧に生成される
+> （[`dogfood/vp-2026-05-26.md`](../dogfood/vp-2026-05-26.md) signal #2 で VP dogfood の
+> 検証 trail）。 datagram の `ChannelMeta` 手書きは [`vp-dashboard.ts` example](../clients/typescript/examples/vp-dashboard.ts)
+> に教材として残っているが、実 use では codegen 経由を推奨。
 
 ### ④ 呼び出し側コードを書く
 


### PR DESCRIPTION
## Summary

VP dashboard を `@chronista-club/unison-client@1.0.0-rc.1` で組み始めた dogfood session 1 (2026-05-26) で crystallize した **3 signal** を repo に landing。 同時に signal #2 関連の docs の前提も update。

- 📄 **new**: `dogfood/vp-2026-05-26.md` — signal #1 (suggestion、 mock + util public 化) / #2 (comment、 datagram codegen 既動) / #3 (concern、 production blocker)
- ✏️ **edit**: `guides/integration-guide.md` §3③ — datagram TS codegen 制約記述を撤回 (= 既に動く事実反映)
- ✏️ **edit**: `clients/typescript/examples/vp-dashboard.ts` — Channel meta コメント整理 (= 教材用手書き / 実 use は codegen 経由)

## Signals 抜粋

| # | type | 一言 |
|---|------|------|
| #1 | suggestion | 範 paste path で 6 file copy 要 (mock + util public 外) — \`/testing\` subpath publish + util public re-export を提案 |
| #2 | comment | datagram codegen は **既に動く** (handoff memo outdated) — 本 PR で docs update 同時 land |
| #3 | concern | codegen \`interface\` ⇏ SDK \`Record\` で **production blocker** — codegen \`type alias\` 化を別 repo PR で handoff |

詳細 + VP 側 verify trail + next action map: \`dogfood/vp-2026-05-26.md\`。

## Test plan

- [x] doc render preview (= \`dogfood/vp-2026-05-26.md\` markdown 構文確認、 mermaid なし)
- [x] integration-guide.md §3③ の link \`../dogfood/vp-2026-05-26.md\` が hit する
- [x] \`clients/typescript/examples/vp-dashboard.ts\` の編集はコメント only (= TS compile に影響なし)
- [ ] club-unison lead review、 signal の判定 + next action 確定

## 別 PR / 別 repo handoff 予定

- signal #1: club-unison TS SDK の \`/testing\` subpath publish + util public re-export PR
- signal #3: club-kdl-codegen repo に \`interface X\` → \`type X = { ... }\` 化 PR

## creo-memories chain

- dev journal: \`mem_1CbPm6RtoPEGnR5cchc8qW\`
- signal annotations on handoff parent (\`mem_1Cb6sMLFXDi8xgrWriPzaE\`):
  - #1 \`mem_1CbPchg7FaWEQdi9tHj55B\` / #2 \`mem_1CbPgMX9eiZ6uJ1ZvzkaDR\` / #3 \`mem_1CbPjGqZ9FVGnoQY8c5SWh\`
- dogfood todo: \`mem_1Cb6sMca3qkNSvsMTthics\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)