### PR TITLE
feat(ts-client): /testing subpath publish + channel util public re-export (dogfood signal #1)

### DIFF
--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -3,7 +3,7 @@
 > TypeScript client SDK for the [Unison protocol](https://github.com/chronista-club/club-unison).
 > Part of the **v1.0 polyglot client base** (= server stays Rust, client polyglot for adoption surface).
 
-**Status**: `1.0.0` — v1.0 GA. Protocol API is frozen and the SDK is shipped to npm. It talks to the Rust server over **real WebTransport** (verified by `tests/integration/webtransport_e2e.test.ts`). See [design/typescript-client-api.md](../../design/typescript-client-api.md) for the SDK design contract.
+**Status**: `1.1.0` — v1.0 GA + `/testing` subpath. Protocol API is frozen and the SDK is shipped to npm. It talks to the Rust server over **real WebTransport** (verified by `tests/integration/webtransport_e2e.test.ts`). See [design/typescript-client-api.md](../../design/typescript-client-api.md) for the SDK design contract.
 
 ---
 
@@ -72,6 +72,43 @@ await echo.close();
 await client.disconnect();
 ```
 
+## Testing utilities (`/testing` subpath)
+
+Drive the SDK end-to-end without a real WebTransport stack or a Rust server —
+`MockTransport` pairs in-memory endpoints and `StreamServerStub` speaks the same
+byte-compatible frame protocol as the Rust server:
+
+```typescript
+import { connect } from "@chronista-club/unison-client";
+import {
+  MockTransport,
+  StreamServerStub,
+} from "@chronista-club/unison-client/testing";
+
+const transport = new MockTransport();
+const { server } = transport.prepare(); // server-side endpoint of the memory pipe
+
+const client = await connect({
+  url: "https://mock.local", // any URL — never dialed with a mock transport
+  transport,
+  awaitIdentity: false,
+});
+
+// Server side: accept the stream and answer with an echo handler.
+const serverSide = (async () => {
+  const accepted = await server.acceptStream();
+  if (accepted.done) throw new Error("no stream");
+  return new StreamServerStub(accepted.value, (_method, payload) => payload);
+})();
+```
+
+`examples/vp-dashboard.ts` and `tests/integration/beta_freeze.test.ts` show the
+full pattern (datagram channels, identity handshake via `sendIdentity`, nack
+injection with `rejectOpen`).
+
+The SDK's own integration tests (`tests/integration/`) import the same module,
+so the published harness can never drift from what CI verifies.
+
 ## Architecture
 
 ```
@@ -83,7 +120,8 @@ clients/typescript/
 │   ├── channel/           ← UnisonChannel / DatagramChannel + dispatcher + frame
 │   ├── codec/             ← JsonCodec + ProtoCodec
 │   ├── wire/              ← Rust-compatible packet / protocol-message encode/decode
-│   └── error/             ← ErrorCategory framework
+│   ├── error/             ← ErrorCategory framework
+│   └── testing/           ← /testing subpath (MockTransport + StreamServerStub)
 ├── examples/              ← vp-dashboard.ts (Vantage Point proof point demo)
 ├── tests/                 ← vitest unit + integration tests (incl. real WebTransport E2E)
 ├── package.json
@@ -105,7 +143,7 @@ npm run typecheck      # tsc --noEmit (= type safety verification)
 ## Versioning policy
 
 - TS package version is kept in **major.minor sync** with the Rust crate `club-unison`
-- `1.0.0` (current) — protocol API frozen, stability committed; breaking changes to the public surface require v2.0
+- `1.1.0` (current) — adds the `/testing` subpath + channel util re-exports; protocol API remains frozen since `1.0.0`; breaking changes to the public surface require v2.0
 - `1.x.0` — additive features (channels, codecs, error codes) that preserve API compatibility
 - `1.0.x` — patch fixes
 

--- a/clients/typescript/bench/channel.bench.ts
+++ b/clients/typescript/bench/channel.bench.ts
@@ -6,7 +6,7 @@
  * - `DatagramChannel` の event 配送 throughput (= dispatcher demux → codec decode
  *   → AsyncQueue 配送) を計測する。
  *
- * 実 WebTransport は使わず `tests/integration/mock_transport.ts` の in-memory pipe
+ * 実 WebTransport は使わず `src/testing/` の in-memory pipe
  * を再利用する。 transport は memory pipe なので I/O コストはほぼゼロ、 計測対象は
  * SDK 側の frame encode/decode + codec + recv loop dispatch である点に注意。
  */
@@ -21,8 +21,7 @@ import type {
 } from "../src/channel/types.js";
 import { UnisonChannelImpl } from "../src/channel/unison_channel.js";
 import { JsonCodec } from "../src/codec/json_codec.js";
-import { MockConnection } from "../tests/integration/mock_transport.js";
-import { StreamServerStub } from "../tests/integration/server_stub.js";
+import { MockConnection, StreamServerStub } from "../src/testing/index.js";
 
 const codec = JsonCodec.shared as JsonCodec<ChannelPayload>;
 

--- a/clients/typescript/examples/vp-dashboard.ts
+++ b/clients/typescript/examples/vp-dashboard.ts
@@ -16,8 +16,12 @@
 import { connect, type ChannelMeta, type DatagramChannelMeta } from "../src/index.js";
 import { JsonCodec } from "../src/codec/json_codec.js";
 import { encodeVarint } from "../src/channel/varint.js";
-import { MockTransport, type MockConnection } from "../tests/integration/mock_transport.js";
-import { StreamServerStub, sendIdentity } from "../tests/integration/server_stub.js";
+import {
+  type MockConnection,
+  MockTransport,
+  sendIdentity,
+  StreamServerStub,
+} from "../src/testing/index.js";
 import type { BidiStream } from "../src/transport/types.js";
 
 // ============================================================

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronista-club/unison-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript client SDK for the Unison protocol (= polyglot client base, server stays Rust)",
   "license": "MIT",
   "type": "module",
@@ -11,6 +11,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing.js"
     }
   },
   "files": [

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -61,8 +61,12 @@ export {
 	decodeTypedFrame,
 	encodeProtocolFrame,
 	encodeRawFrame,
+	readFrames,
 } from "./channel/frame.js";
 export type { DecodedFrame } from "./channel/frame.js";
+// channel 実装 util (= dogfood signal #1: 範の写経で internal copy させない)
+export { AsyncQueue } from "./channel/async_queue.js";
+export { encodeVarint } from "./channel/varint.js";
 export { decodePacket, encodePacket } from "./wire/packet.js";
 export type { DecodedPacket, PacketOptions } from "./wire/packet.js";
 export {
@@ -112,4 +116,4 @@ export type { UnisonConnectOptions } from "./client.js";
 export { UnisonClient, connect } from "./client.js";
 
 // SDK version (= package.json と同期)
-export const VERSION = "1.0.0";
+export const VERSION = "1.1.0";

--- a/clients/typescript/src/testing/index.ts
+++ b/clients/typescript/src/testing/index.ts
@@ -1,0 +1,30 @@
+/**
+ * `@chronista-club/unison-client/testing` — 公式 mock harness subpath
+ *
+ * 実 WebTransport / Rust server なしで SDK を E2E 駆動するための test 基盤。
+ * dogfood signal #1 (= `dogfood/vp-2026-05-26.md`) で「範の写経に 6 file copy が
+ * 要る」friction が報告され、`npm install` + import 1 行に圧縮するために公開した。
+ *
+ * - `MockTransport` / `MockConnection`: in-memory `Transport` / `Connection` 実装
+ * - `StreamServerStub`: Rust `quic.rs` と byte 互換の frame echo server
+ * - `TEST_IDENTITY` / `sendIdentity`: identity handshake fixture
+ *
+ * SDK 本体の integration test (`tests/integration/`) もここを import する
+ * (= 配布物と test 基盤が同一 source、 乖離しない)。
+ */
+
+export {
+	makeBidiPair,
+	MockConnection,
+	MockTransport,
+} from "./mock_transport.js";
+export type {
+	ReceivedEvent,
+	RequestHandler,
+	StreamServerStubOptions,
+} from "./server_stub.js";
+export {
+	sendIdentity,
+	StreamServerStub,
+	TEST_IDENTITY,
+} from "./server_stub.js";

--- a/clients/typescript/src/testing/mock_transport.ts
+++ b/clients/typescript/src/testing/mock_transport.ts
@@ -15,8 +15,8 @@ import type {
   ConnectionEvent,
   ConnectOptions,
   Transport,
-} from "../../src/transport/types.js";
-import { AsyncQueue } from "../../src/channel/async_queue.js";
+} from "../transport/types.js";
+import { AsyncQueue } from "../channel/async_queue.js";
 
 /** 片方向 byte pipe。 `endReadable` で読み手側を即終端できる (= reader cancel 相当) */
 interface BytePipe {

--- a/clients/typescript/src/testing/server_stub.ts
+++ b/clients/typescript/src/testing/server_stub.ts
@@ -12,20 +12,20 @@
  * [UnisonPacket]`) で Rust `quic.rs` と byte 一致する。
  */
 
-import type { BidiStream, Connection } from "../../src/transport/types.js";
+import type { BidiStream, Connection } from "../transport/types.js";
 import {
   decodeTypedFrame,
   encodeProtocolFrame,
   readFrames,
-} from "../../src/channel/frame.js";
+} from "../channel/frame.js";
 import {
   MSG_TYPE_ERROR,
   MSG_TYPE_EVENT,
   MSG_TYPE_REQUEST,
   MSG_TYPE_RESPONSE,
-} from "../../src/wire/protocol_message.js";
-import { JsonCodec } from "../../src/codec/json_codec.js";
-import type { ServerIdentity } from "../../src/channel/identity.js";
+} from "../wire/protocol_message.js";
+import { JsonCodec } from "../codec/json_codec.js";
+import type { ServerIdentity } from "../channel/identity.js";
 
 const codec = JsonCodec.shared;
 const textEncoder = new TextEncoder();

--- a/clients/typescript/tests/integration/beta_freeze.test.ts
+++ b/clients/typescript/tests/integration/beta_freeze.test.ts
@@ -20,8 +20,11 @@ import type {
   ResponseType,
 } from "../../src/channel/types.js";
 import { JsonCodec } from "../../src/codec/json_codec.js";
-import { MockConnection, MockTransport } from "./mock_transport.js";
-import { StreamServerStub } from "./server_stub.js";
+import {
+  MockConnection,
+  MockTransport,
+  StreamServerStub,
+} from "../../src/testing/index.js";
 
 // --- 生成 meta の代用 (= codegen 出力相当、 `__types` phantom carrier 込み) ---
 

--- a/clients/typescript/tests/integration/codec_channel.test.ts
+++ b/clients/typescript/tests/integration/codec_channel.test.ts
@@ -9,8 +9,7 @@ import { describe, expect, it } from "vitest";
 import { UnisonChannelImpl } from "../../src/channel/unison_channel.js";
 import type { ChannelMeta, ChannelPayload } from "../../src/channel/types.js";
 import { JsonCodec } from "../../src/codec/json_codec.js";
-import { MockConnection } from "./mock_transport.js";
-import { StreamServerStub } from "./server_stub.js";
+import { MockConnection, StreamServerStub } from "../../src/testing/index.js";
 
 const EchoMeta = {
   name: "echo",

--- a/clients/typescript/tests/integration/datagram_channel.test.ts
+++ b/clients/typescript/tests/integration/datagram_channel.test.ts
@@ -11,7 +11,7 @@ import { DatagramDispatcher } from "../../src/channel/dispatcher.js";
 import type { DatagramChannelMeta } from "../../src/channel/types.js";
 import type { ChannelPayload } from "../../src/channel/types.js";
 import { JsonCodec } from "../../src/codec/json_codec.js";
-import { MockConnection } from "./mock_transport.js";
+import { MockConnection } from "../../src/testing/index.js";
 
 function datagramMeta<const Id extends number, const Name extends string>(
   name: Name,

--- a/clients/typescript/tests/integration/teardown.test.ts
+++ b/clients/typescript/tests/integration/teardown.test.ts
@@ -12,8 +12,7 @@ import { DatagramDispatcher } from "../../src/channel/dispatcher.js";
 import type { ChannelMeta, DatagramChannelMeta, ChannelPayload } from "../../src/channel/types.js";
 import type { ConnectionEvent } from "../../src/transport/types.js";
 import { JsonCodec } from "../../src/codec/json_codec.js";
-import { MockConnection } from "./mock_transport.js";
-import { StreamServerStub } from "./server_stub.js";
+import { MockConnection, StreamServerStub } from "../../src/testing/index.js";
 
 const StreamMeta = {
   name: "ctl",

--- a/clients/typescript/tests/integration/unison_channel.test.ts
+++ b/clients/typescript/tests/integration/unison_channel.test.ts
@@ -10,8 +10,7 @@ import { UnisonChannelImpl } from "../../src/channel/unison_channel.js";
 import type { ChannelMeta } from "../../src/channel/types.js";
 import { JsonCodec } from "../../src/codec/json_codec.js";
 import type { ChannelPayload } from "../../src/channel/types.js";
-import { MockConnection } from "./mock_transport.js";
-import { StreamServerStub } from "./server_stub.js";
+import { MockConnection, StreamServerStub } from "../../src/testing/index.js";
 
 const ControlMeta = {
   name: "control",

--- a/clients/typescript/vite.config.ts
+++ b/clients/typescript/vite.config.ts
@@ -4,17 +4,21 @@ import { resolve } from "node:path";
 /**
  * Vite config for @chronista-club/unison-client TS SDK (= v1.0 polyglot Phase 2)
  *
- * - Library build mode (= 単一 entry index.ts、 dist/ に ESM 出力)
+ * - Library build mode (= index + testing の 2 entry、 dist/ に ESM 出力)
  * - Type definitions は別途 `tsc --emitDeclarationOnly` で生成 (= package.json build script)
  * - Bundle size 目標: core ≤ 100KB / +Proto ≤ 200KB minified gzipped
  */
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(import.meta.dirname, "src/index.ts"),
+      entry: {
+        index: resolve(import.meta.dirname, "src/index.ts"),
+        // `/testing` subpath (= dogfood signal #1、 mock harness 公式配布)
+        testing: resolve(import.meta.dirname, "src/testing/index.ts"),
+      },
       name: "UnisonClient",
       formats: ["es"],
-      fileName: "index",
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
     sourcemap: true,
     minify: "esbuild",


### PR DESCRIPTION
## 概要

VP dogfood session 1 (#65, `dogfood/vp-2026-05-26.md`) の **signal #1** 解消。範 `vp-dashboard.ts` の写経に 6 file の source copy が要った friction を「`npm install` + import 1 行」に圧縮する。

## 変更

### 1. `/testing` subpath publish
- `tests/integration/` の mock harness (`mock_transport.ts` / `server_stub.ts`) を `src/testing/` へ**移動**(コピーは残さない)
- `@chronista-club/unison-client/testing` で `MockTransport` / `MockConnection` / `makeBidiPair` / `StreamServerStub` / `sendIdentity` / `TEST_IDENTITY` を配布
- vite lib build を `index` + `testing` の 2 entry 化、`package.json` `exports` に `./testing` 追加

### 2. internal util の public re-export
- `AsyncQueue` / `encodeVarint` / `readFrames` を `index.ts` に追加(signal #1 で挙がった「`dist/index.d.ts` re-export 漏れ」3 件)

### 3. 同一 source 原則
- SDK 自身の integration test (5 file) / bench / example も `src/testing/` barrel を import — 配布物と test 基盤が乖離しない

### 4. version 1.0.0 → 1.1.0
- additive feature = `1.x.0`(README versioning policy 準拠)
- Rust crate workspace `1.1.0` との major.minor 同期も回復

### スコープ外
- signal #1 proposal ③(examples の npm/docs site 配布)は discussion 持ち越し
- signal #3(codegen `type alias` 化)は club-kdl-codegen repo の別 handoff

## 検証

- [x] `tsc --noEmit` + `tsc -p tsconfig.test.json` exit 0
- [x] `vitest run` 85/85 pass(実 WebTransport E2E 含む)
- [x] `vite build` → `dist/testing.js` 6.16 kB + 共有チャンク分割
- [x] `bun pm pack --dry-run` で `dist/testing.js` / `dist/testing/index.d.ts` の同梱確認
- [x] built 成果物の runtime import で全 export 存在確認(bun)
- [x] README の `/testing` snippet は実 API(`transport.prepare()` → `acceptStream()` → `StreamServerStub`)で記述

🤖 Generated with [Claude Code](https://claude.com/claude-code)