### PR TITLE
docs(dogfood): VP dogfood session 1 全 signal クローズ追記

### DIFF
--- a/dogfood/vp-2026-05-26.md
+++ b/dogfood/vp-2026-05-26.md
@@ -174,6 +174,15 @@ $ cd crates/vp-app/web-bundle && bun run build
 | #2 | `guides/integration-guide.md` §3③ + `examples/vp-dashboard.ts` コメント update | club-unison docs | ✅ 同 PR で land |
 | #3 | codegen `interface` → `type alias` 化 | **club-kdl-codegen repo** | ❌ 別 repo handoff |
 
+### 解決追記 (2026-06-11)
+
+全 signal クローズ済み:
+
+- **#1**: PR #70 で land (`/testing` subpath + `AsyncQueue` / `encodeVarint` / `readFrames` re-export、 SDK `1.1.0`)
+- **#3**: club-kdl PR #23 (2026-05-20、 v0.10.0 収録) が proposal option 1 をそのまま実装済みだった。
+  codegen `0.11.1` の生成物で SDK `ChannelMeta` への代入 + response narrowing を tsc 検証 → pass。
+  interface 形に戻すと本 doc 記載のエラーが正確に再現することも確認 (= probe の妥当性担保)。
+
 ## chain (= memory references)
 
 - VP 側 dev journal (= 本 session の総括): creo-memories `mem_1CbPm6RtoPEGnR5cchc8qW`


### PR DESCRIPTION
## 概要

`dogfood/vp-2026-05-26.md` の next action map に解決追記を追加。3 signal 全クローズ。

- **#1**: PR #70 で land(`/testing` subpath + util re-export、SDK 1.1.0)
- **#2**: PR #65 で land 済み(既記録)
- **#3**: **club-kdl PR #23(2026-05-20、v0.10.0 収録)で既に解決済みと判明**。dogfood 報告(5/26)は codegen 0.9.0 pin 時点のもので、修正は報告の 6 日前にマージされていた

## #3 の検証

元の再現環境(VP の Dashboard.ts draft)は未コミットのまま消滅していたため、最小構成で再検証:

1. dogfood と同形の KDL schema(`SubscribeMetric` → `Subscribed`)を codegen **0.11.1** で生成 → `export type ControlChannelRequestTypes = {` (type alias)
2. 実 SDK(`clients/typescript/dist`)の `ChannelMeta` への代入 + `request()` response narrowing probe → **tsc exit 0**
3. negative test: 生成物を interface 形に戻すと doc 記載の `Index signature for type 'string' is missing` が正確に再現 → probe は本物

🤖 Generated with [Claude Code](https://claude.com/claude-code)