### PR TITLE
fix(ts-client): cert-pinning gate が bracketed IPv6 [::1] を弾く回帰修正

### DIFF
--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -3,7 +3,7 @@
 > TypeScript client SDK for the [Unison protocol](https://github.com/chronista-club/club-unison).
 > Part of the **v1.0 polyglot client base** (= server stays Rust, client polyglot for adoption surface).
 
-**Status**: `1.1.0` — v1.0 GA + `/testing` subpath. Protocol API is frozen and the SDK is shipped to npm. It talks to the Rust server over **real WebTransport** (verified by `tests/integration/webtransport_e2e.test.ts`). See [design/typescript-client-api.md](../../design/typescript-client-api.md) for the SDK design contract.
+**Status**: `1.1.1` — v1.0 GA + `/testing` subpath. Protocol API is frozen and the SDK is shipped to npm. It talks to the Rust server over **real WebTransport** (verified by `tests/integration/webtransport_e2e.test.ts`). See [design/typescript-client-api.md](../../design/typescript-client-api.md) for the SDK design contract.
 
 ---
 

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chronista-club/unison-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TypeScript client SDK for the Unison protocol (= polyglot client base, server stays Rust)",
   "license": "MIT",
   "type": "module",

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -116,4 +116,4 @@ export type { UnisonConnectOptions } from "./client.js";
 export { UnisonClient, connect } from "./client.js";
 
 // SDK version (= package.json と同期)
-export const VERSION = "1.1.0";
+export const VERSION = "1.1.1";

--- a/clients/typescript/src/transport/web_transport.ts
+++ b/clients/typescript/src/transport/web_transport.ts
@@ -22,8 +22,14 @@ const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 /**
  * cert pinning は loopback host にのみ許可する hard gate。
  * 非 loopback への pinning は本番想定の誤用なので throw。
+ *
+ * @internal export は単体テスト用 (= WebTransport 不在の node 環境では
+ * `connect()` 経由でゲートに到達できないため、 gate を直接検証する)。
  */
-function enforceTrustGate(url: string, trust: TrustMode | undefined): void {
+export function enforceTrustGate(
+  url: string,
+  trust: TrustMode | undefined,
+): void {
   if (trust === undefined || trust === "system") return;
   let host: string;
   try {
@@ -31,7 +37,10 @@ function enforceTrustGate(url: string, trust: TrustMode | undefined): void {
   } catch {
     throw new Error(`invalid connection URL: ${url}`);
   }
-  if (!LOOPBACK_HOSTS.has(host)) {
+  // URL.hostname は IPv6 を角括弧付きで返す (= `[::1]`) が LOOPBACK_HOSTS は
+  // 括弧なし (= `::1`) で保持するため、 比較前に外側の角括弧を剥がして正規化。
+  const normalizedHost = host.replace(/^\[|\]$/g, "");
+  if (!LOOPBACK_HOSTS.has(normalizedHost)) {
     throw new Error(
       `cert pinning (skip-verify) is restricted to localhost; got host "${host}"`,
     );

--- a/clients/typescript/tests/transport/trust_gate.test.ts
+++ b/clients/typescript/tests/transport/trust_gate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { enforceTrustGate } from "../../src/transport/web_transport.js";
+
+const HASH_TRUST = {
+  certHash:
+    "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+} as const;
+
+describe("enforceTrustGate", () => {
+  it("allows cert pinning on IPv4 loopback", () => {
+    expect(() =>
+      enforceTrustGate("https://127.0.0.1:4439", HASH_TRUST),
+    ).not.toThrow();
+  });
+
+  it("allows cert pinning on localhost", () => {
+    expect(() =>
+      enforceTrustGate("https://localhost:4439", HASH_TRUST),
+    ).not.toThrow();
+  });
+
+  // 回帰: URL.hostname は IPv6 を `[::1]` と角括弧付きで返すため、
+  // 正規化前は `::1` と照合 miss し loopback でも throw していた。
+  it("allows cert pinning on bracketed IPv6 loopback [::1]", () => {
+    expect(() =>
+      enforceTrustGate("https://[::1]:4439", HASH_TRUST),
+    ).not.toThrow();
+  });
+
+  it("rejects cert pinning on a non-loopback host", () => {
+    expect(() => enforceTrustGate("https://example.com:443", HASH_TRUST)).toThrow(
+      /restricted to localhost/,
+    );
+  });
+
+  it("rejects cert pinning on a non-loopback IPv6 host", () => {
+    expect(() =>
+      enforceTrustGate("https://[2001:db8::1]:443", HASH_TRUST),
+    ).toThrow(/restricted to localhost/);
+  });
+
+  it("skips the gate for system trust and undefined", () => {
+    expect(() =>
+      enforceTrustGate("https://example.com:443", "system"),
+    ).not.toThrow();
+    expect(() =>
+      enforceTrustGate("https://example.com:443", undefined),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 概要

VP webview console bridge の Unison echo probe verify recipe で発見された handoff(from `agent@vantage-point`)の解消。

`clients/typescript/src/transport/web_transport.ts` の `enforceTrustGate` が、`URL.hostname` の返す角括弧付き IPv6(`[::1]`)を `LOOPBACK_HOSTS`(括弧なし `::1`)と照合して miss → loopback への cert pinning(skip-verify)接続が**常に throw** していた。

結果、`https://[::1]:port` への WebTransport 接続が全て弾かれる。`127.0.0.1` / `localhost` は無影響。

## 修正

- host 比較前に外側の角括弧を剥がして正規化: `host.replace(/^\[|\]$/g, "")`
- `enforceTrustGate` を `export`(WebTransport 不在の node テスト環境では `connect()` が先に `WebTransportUnsupportedError` を投げ、ゲートに到達できないため、gate を直接検証する)
- 回帰テスト 6 件追加(`tests/transport/trust_gate.test.ts`): IPv4 loopback / localhost / **bracketed IPv6 `[::1]`** / 非 loopback host / 非 loopback IPv6 / system・undefined skip
- version 1.1.0 → 1.1.1(patch)

## 検証

- [x] `tsc --noEmit` + `tsc -p tsconfig.test.json` exit 0
- [x] `vitest run` **91/91 pass**(+6 新規、実 WebTransport E2E 含む)
- [x] **negative test**: 正規化を外すと `[::1]` テストだけが正確に落ちることを確認 → fix の妥当性担保
- [x] `vite build` → `dist/` 再生成(VP は `file:` link で dist/ を import するため必須)

## follow-up

- npm への 1.1.1 publish は別途(VP は file: link 経由なので本 PR の dist 再生成で echo round-trip は解消)

🤖 Generated with [Claude Code](https://claude.com/claude-code)