### PR TITLE
feat(protocol): raw QUIC に ALPN "unison" を設定 (RFC 9001 準拠 + Apple interop)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/crates/unison-protocol/src/network/mod.rs
+++ b/crates/unison-protocol/src/network/mod.rs
@@ -6,6 +6,16 @@ use crate::codec::{CodecError, Decodable, Encodable, JsonCodec};
 use crate::packet::{SerializationError, UnisonPacket};
 use crate::proto;
 
+/// raw QUIC 経路の ALPN protocol id。
+///
+/// QUIC は ALPN を必須とする (RFC 9001 §8.1 — endpoints MUST use ALPN)。
+/// raw QUIC の server ([`quic::QuicServer`]) と client ([`trust::TrustAnchors`])
+/// は同一 label で合意する必要があるため、 ここを SSOT とする。
+///
+/// WebTransport 経路 ([`webtransport`]) は HTTP/3 上に乗るため ALPN は `"h3"`
+/// 固定 (`wtransport` 依存が内部で設定) であり、 本 const は適用されない。
+pub const UNISON_ALPN: &[u8] = b"unison";
+
 pub mod cert;
 pub mod channel;
 pub mod client;

--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -570,9 +570,13 @@ impl QuicServer {
 
         // CertifiedKey holds both cert chain and signing key in a single Arc,
         // avoiding any clone_key() of the private key (zeroize-friendlier).
-        let rustls_server_config = RustlsServerConfig::builder()
+        let mut rustls_server_config = RustlsServerConfig::builder()
             .with_no_client_auth()
             .with_cert_resolver(Arc::new(SingleCertResolver(certified_key)));
+
+        // QUIC は ALPN 必須 (RFC 9001 §8.1)。 client (trust.rs) と同一 label で
+        // 合意する。 SSOT は `super::UNISON_ALPN`。
+        rustls_server_config.alpn_protocols = vec![super::UNISON_ALPN.to_vec()];
 
         let crypto = quinn::crypto::rustls::QuicServerConfig::try_from(rustls_server_config)?;
         let mut server_config = ServerConfig::with_crypto(Arc::new(crypto));

--- a/crates/unison-protocol/src/network/trust.rs
+++ b/crates/unison-protocol/src/network/trust.rs
@@ -52,14 +52,13 @@ pub enum TrustAnchors {
 impl TrustAnchors {
     /// Build the underlying [`rustls::ClientConfig`] for this trust mode.
     pub fn build_client_config(self) -> Result<Arc<rustls::ClientConfig>> {
-        match self {
+        let mut config = match self {
             Self::System => {
                 let mut roots = RootCertStore::empty();
                 roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-                let config = rustls::ClientConfig::builder()
+                rustls::ClientConfig::builder()
                     .with_root_certificates(roots)
-                    .with_no_client_auth();
-                Ok(Arc::new(config))
+                    .with_no_client_auth()
             }
             Self::Custom(certs) => {
                 let mut roots = RootCertStore::empty();
@@ -68,23 +67,27 @@ impl TrustAnchors {
                         .add(cert)
                         .context("failed to add custom CA certificate to root store")?;
                 }
-                let config = rustls::ClientConfig::builder()
+                rustls::ClientConfig::builder()
                     .with_root_certificates(roots)
-                    .with_no_client_auth();
-                Ok(Arc::new(config))
+                    .with_no_client_auth()
             }
             Self::SkipVerification => {
                 tracing::warn!(
                     "TrustAnchors::SkipVerification — server certificates will NOT be \
                      verified. DEV / TEST ONLY, never use in production."
                 );
-                let config = rustls::ClientConfig::builder()
+                rustls::ClientConfig::builder()
                     .dangerous()
                     .with_custom_certificate_verifier(Arc::new(SkipServerVerification))
-                    .with_no_client_auth();
-                Ok(Arc::new(config))
+                    .with_no_client_auth()
             }
-        }
+        };
+
+        // QUIC は ALPN 必須 (RFC 9001 §8.1)。 server (quic.rs) と同一 label で
+        // 合意する。 全 trust mode 共通。 SSOT は `super::UNISON_ALPN`。
+        config.alpn_protocols = vec![super::UNISON_ALPN.to_vec()];
+
+        Ok(Arc::new(config))
     }
 }
 
@@ -140,5 +143,29 @@ impl ServerCertVerifier for SkipServerVerification {
             SignatureScheme::ED25519,
             SignatureScheme::ED448,
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// QUIC は ALPN 必須 (RFC 9001 §8.1)。 全 trust mode が `super::UNISON_ALPN` を
+    /// client config に設定すること = server (quic.rs) と確実に label 合意できること
+    /// を回帰として担保する (Apple `NWProtocolQUIC` 等の厳格実装との interop 前提)。
+    #[test]
+    fn every_trust_mode_advertises_unison_alpn() {
+        let expected = vec![super::super::UNISON_ALPN.to_vec()];
+        for anchors in [
+            TrustAnchors::System,
+            TrustAnchors::Custom(vec![]),
+            TrustAnchors::SkipVerification,
+        ] {
+            let config = anchors.build_client_config().expect("build client config");
+            assert_eq!(
+                config.alpn_protocols, expected,
+                "client config must advertise the unison ALPN"
+            );
+        }
     }
 }


### PR DESCRIPTION
## 概要

Swift native client (NWProtocolQUIC) 実装の前提整備。raw QUIC 経路が **ALPN を一切設定していない**問題を解消する。

## 背景

- `quic.rs` の rustls ServerConfig / `trust.rs` の client config は `alpn_protocols` を設定せず、**空 ALPN で handshake** していた(リポジトリ全体で ALPN 設定箇所ゼロ)
- quinn↔quinn(および Ruby は FFI で Rust client 経由)が動いていたのは**両端とも enforcement を緩めているため**で、厳密には spec 逸脱
- **QUIC は RFC 9001 §8.1 で ALPN を必須**とする(endpoints MUST use ALPN)。Apple の `NWProtocolQUIC` は ALPN を強制するため、空 ALPN サーバーには `no_application_protocol` で handshake が落ちる → Swift client が成立しない

## 変更

- `network::UNISON_ALPN` (`b"unison"`) を **SSOT const** として追加(server/client の drift 防止)
- **server** (`quic.rs`): `rustls_server_config.alpn_protocols = vec![UNISON_ALPN]`
- **client** (`trust.rs`): `build_client_config` を restructure し、全 trust mode(System / Custom / SkipVerification)で ALPN を設定
- 回帰テスト: 全 trust mode が `unison` ALPN を advertise すること
- workspace 1.2.0 → 1.3.0(additive: 新 public const + wire 挙動変化)

## 影響範囲

| 経路 | ALPN | 本変更 |
|---|---|---|
| raw QUIC(Rust client / Ruby FFI / 新 Swift) | `"unison"` | ✅ 追加 |
| WebTransport(TS / ブラウザ) | `"h3"` 固定(wtransport 依存が内部設定) | 無関係(別 ingress・別 listener) |

raw QUIC は server/client 両端が同 label を negotiate するため **Rust↔Rust / Ruby は後方互換**。rustls は片側のみ ALPN の場合 negotiation を skip するため、旧↔新の混在でも handshake は成立する。

## 検証

- [x] `cargo test --workspace` 全 pass(0 failed)
- [x] `cargo test --workspace -- --ignored` 全 pass(実 QUIC handshake: identity handshake / connection lifecycle / mesh trust SAN match)
- [x] `cargo clippy --lib --workspace -- -D warnings` clean
- [x] 回帰テスト `every_trust_mode_advertises_unison_alpn` 追加

## follow-up

- 本 PR は Swift native client (`clients/swift`) 実装の前提。後続で Swift package を scaffold
- crates.io 1.3.0 publish は別途判断(Swift client は Rust crate を消費しないが、ALPN 対応サーバーを使う consumer 向け)

🤖 Generated with [Claude Code](https://claude.com/claude-code)