### PR TITLE
feat(swift): channel 状態機械 (open/request-response/event/identity) を実装

### DIFF
--- a/clients/swift/README.md
+++ b/clients/swift/README.md
@@ -61,11 +61,15 @@ struct Ping: UnisonRequest {
 | QUIC transport / handshake(ALPN "unison" + trust policy) | ✅ (`NWProtocolQUIC`、spike で quinn 疎通実証済み) |
 | wire framing(typed frame / UnisonPacket / ProtocolMessage encode・decode）| ✅ (Rust golden fixture と **byte 一致**検証済み) |
 | `FrameReader`（chunk 跨ぎ frame 再構成） | ✅ |
+| `ChannelStream` / `ChannelTransport` 抽象 | ✅ (transport をロジックから分離) |
+| `__channel:` mux（open frame → open_ack 待ち） | ✅ (in-memory test 済み) |
+| identity handshake / `serverIdentity()` | ✅ (in-memory test 済み) |
+| `StreamChannel.request` / `events` 実配線 | ✅ (request/response + event push、in-memory test 済み) |
+| **NWProtocolQUIC stream adapter**（`QUICTransport.openStream`/`acceptStream`） | ⬜ TODO (= 抽象を実 QUIC stream に接続、live e2e) |
 | `Endpoint.bonjour` discovery | ⬜ TODO |
-| `__channel:` mux（open frame → open_ack 待ち） | ⬜ TODO |
-| identity handshake / `serverIdentity()` | ⬜ TODO |
-| `StreamChannel.request` / `events` 実配線 | ⬜ TODO |
 | `DatagramChannel.events`(QUIC datagram demux) | ⬜ TODO |
+
+> **テスト戦略**: channel 状態機械(open / request-response / event / identity)は `ChannelStream` 抽象 + in-memory paired stream で決定論的に検証(`ChannelTests`)。NWProtocolQUIC の実 stream は次 pass でこの抽象に adapt し、`unison mock` 相手の live e2e を通す。
 
 ## 開発
 

--- a/clients/swift/Sources/UnisonClient/Channel.swift
+++ b/clients/swift/Sources/UnisonClient/Channel.swift
@@ -4,25 +4,44 @@ import Foundation
 ///
 /// `Connection.openChannel(_:)` が返す。 `M` で event / request の型が静的に決まる。
 public struct StreamChannel<M: StreamChannelMeta>: Sendable {
-    private let core: ChannelCore
+    private let core: StreamChannelCore
 
-    init(core: ChannelCore) {
+    init(core: StreamChannelCore) {
         self.core = core
     }
 
-    /// server → client の push event ストリーム。
+    /// server → client の push event ストリーム。 wire payload を `M.Event` へ
+    /// JSON decode する。 decode 不能な event は skip する。
     public var events: AsyncStream<M.Event> {
-        // TODO(next pass): typed-frame dispatch を decode して M.Event を流す。
-        // scaffold 段階では即終端の空ストリームを返す。
-        AsyncStream { $0.finish() }
+        let raw = core.eventStream
+        return AsyncStream { continuation in
+            let task = Task {
+                let decoder = JSONDecoder()
+                for await msg in raw {
+                    if let event = try? decoder.decode(M.Event.self, from: msg.payload) {
+                        continuation.yield(event)
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
     }
 
     /// request を 1 本送り、 対応する response を待つ。
     public func request<R: UnisonRequest>(_ request: R) async throws -> R.Response {
-        // TODO(next pass): R.method + payload を typed frame に乗せて送信し、
-        // 同 id の response frame を await して R.Response に decode する。
-        _ = request
-        throw UnisonError.notImplemented("StreamChannel.request")
+        let payload: Data
+        do {
+            payload = try JSONEncoder().encode(request)
+        } catch {
+            throw UnisonError.codec("request encode 失敗: \(error)")
+        }
+        let responseBytes = try await core.request(method: R.method, payload: payload)
+        do {
+            return try JSONDecoder().decode(R.Response.self, from: responseBytes)
+        } catch {
+            throw UnisonError.codec("response decode 失敗: \(error)")
+        }
     }
 
     /// channel を閉じる。
@@ -32,14 +51,16 @@ public struct StreamChannel<M: StreamChannelMeta>: Sendable {
 }
 
 /// datagram channel ハンドル (= unreliable な server push event 専用)。
+///
+/// QUIC datagram (RFC9221) の demux は後続 pass。 現状は型 surface のみ。
 public struct DatagramChannel<M: DatagramChannelMeta>: Sendable {
-    private let core: ChannelCore
+    private let name: String
 
-    init(core: ChannelCore) {
-        self.core = core
+    init(name: String) {
+        self.name = name
     }
 
-    /// server → client の push event ストリーム (QUIC datagram, RFC9221)。
+    /// server → client の push event ストリーム (QUIC datagram)。
     public var events: AsyncStream<M.Event> {
         // TODO(next pass): datagram demux → M.Event decode。
         AsyncStream { $0.finish() }
@@ -47,23 +68,6 @@ public struct DatagramChannel<M: DatagramChannelMeta>: Sendable {
 
     /// channel を閉じる。
     public func close() async {
-        await core.close()
-    }
-}
-
-/// channel の内部状態 (transport stream / datagram subscription の保持先)。
-///
-/// scaffold 段階では close のみ。 後続 pass で send/recv loop と frame dispatch を持つ。
-actor ChannelCore {
-    let name: String
-    private var closed = false
-
-    init(name: String) {
-        self.name = name
-    }
-
-    func close() {
-        closed = true
-        // TODO(next pass): 紐づく QUIC stream / datagram subscription を tear down。
+        // TODO(next pass): datagram subscription tear down。
     }
 }

--- a/clients/swift/Sources/UnisonClient/ChannelMeta.swift
+++ b/clients/swift/Sources/UnisonClient/ChannelMeta.swift
@@ -10,15 +10,17 @@ public protocol ChannelMeta: Sendable {
 }
 
 /// stream backend の channel meta (= request/response + server push event)。
+///
+/// `Event` は wire payload (= 既定 JSON codec) から decode するため `Decodable`。
 public protocol StreamChannelMeta: ChannelMeta {
     /// この channel が server から push する event の型。
-    associatedtype Event: Sendable
+    associatedtype Event: Sendable & Decodable
 }
 
 /// datagram backend の channel meta (= unreliable な server push event 専用)。
 public protocol DatagramChannelMeta: ChannelMeta {
     /// この channel が server から push する event の型。
-    associatedtype Event: Sendable
+    associatedtype Event: Sendable & Decodable
 }
 
 /// channel 上で送る request。 method 名と response 型を静的に紐づける。
@@ -27,9 +29,11 @@ public protocol DatagramChannelMeta: ChannelMeta {
 /// `request<R: M.Request>` を `request<R: UnisonRequest>` に置き換えている
 /// (= associatedtype を generic constraint に使えない Swift の制約を、 caller 体験を
 /// 損なわず回避)。
-public protocol UnisonRequest: Sendable {
+///
+/// wire は既定 JSON codec のため request は `Encodable`、 response は `Decodable`。
+public protocol UnisonRequest: Sendable & Encodable {
     /// この request に対する response の型。
-    associatedtype Response: Sendable
+    associatedtype Response: Sendable & Decodable
     /// wire 上の method 名。
     static var method: String { get }
 }

--- a/clients/swift/Sources/UnisonClient/Connection.swift
+++ b/clients/swift/Sources/UnisonClient/Connection.swift
@@ -27,11 +27,11 @@ public struct ServerIdentity: Sendable, Equatable {
 
 /// 確立済みの Unison 接続。 channel の open と lifecycle event を提供する。
 public actor Connection {
-    private let transport: QUICTransport
-    private let events: AsyncStream<ConnectionEvent>
-    private let eventSink: AsyncStream<ConnectionEvent>.Continuation
+    private let transport: any ChannelTransport
+    private nonisolated let events: AsyncStream<ConnectionEvent>
+    private nonisolated let eventSink: AsyncStream<ConnectionEvent>.Continuation
 
-    init(transport: QUICTransport) {
+    init(transport: any ChannelTransport) {
         self.transport = transport
         let (stream, sink) = AsyncStream<ConnectionEvent>.makeStream()
         self.events = stream
@@ -44,31 +44,34 @@ public actor Connection {
         events
     }
 
-    /// server の自己記述を取得する。
+    /// server の自己記述を取得する (= identity stream を accept して読む)。
     public func serverIdentity() async throws -> ServerIdentity {
-        // TODO(next pass): identity handshake frame を読んで decode する。
-        throw UnisonError.notImplemented("Connection.serverIdentity")
+        guard let stream = try await transport.acceptStream() else {
+            throw UnisonError.notConnected
+        }
+        return try await IdentityHandshake.read(from: stream)
     }
 
-    /// stream channel を開く。
+    /// stream channel を開く (= 新 stream → `__channel:{name}` open → open_ack 待ち)。
     public func openChannel<M: StreamChannelMeta>(_ meta: M) async throws -> StreamChannel<M> {
         _ = meta
-        // TODO(next pass): `__channel:{name}` open frame 送信 → open_ack 待ち。
-        let core = ChannelCore(name: M.name)
+        let stream = try await transport.openStream()
+        let core = StreamChannelCore(name: M.name, stream: stream)
+        await core.start()
+        try await core.open()
         return StreamChannel(core: core)
     }
 
     /// datagram channel を開く。
     public func openDatagramChannel<M: DatagramChannelMeta>(_ meta: M) async throws -> DatagramChannel<M> {
         _ = meta
-        // TODO(next pass): datagram channel 登録 + channelId 紐づけ。
-        let core = ChannelCore(name: M.name)
-        return DatagramChannel(core: core)
+        // TODO(next pass): datagram channel 登録 + channelId 紐づけ (QUIC datagram)。
+        return DatagramChannel(name: M.name)
     }
 
     /// 接続を切断する。
     public func disconnect() async {
-        await transport.cancel()
+        await transport.close()
         eventSink.yield(.disconnected(reason: nil))
         eventSink.finish()
     }

--- a/clients/swift/Sources/UnisonClient/Internal/IdentityHandshake.swift
+++ b/clients/swift/Sources/UnisonClient/Internal/IdentityHandshake.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Identity handshake — server 自己紹介の受信 (= TS `identity.ts` の Swift port)。
+///
+/// Unison server は接続直後に bidi stream を 1 本 open し、 そこへ `__identity`
+/// の `ProtocolMessage` (= msgType event、 payload は JSON 化した ServerIdentity)
+/// を 1 本送って stream を finish する (= Rust `quic.rs::handle_connection`)。
+enum IdentityHandshake {
+    static let method = "__identity"
+
+    /// 1 本の identity stream を drain して [`ServerIdentity`] を返す。
+    static func read(from stream: any ChannelStream) async throws -> ServerIdentity {
+        var reader = FrameReader()
+        while let chunk = try await stream.receive() {
+            reader.append(chunk)
+            while let body = try reader.nextFrame() {
+                guard case let .protocolMessage(msg) = try Framing.decodeFrameBody(body) else {
+                    throw UnisonError.codec("identity: PROTOCOL frame を期待")
+                }
+                guard msg.method == method else {
+                    throw UnisonError.codec("identity: method \"\(method)\" を期待、 got \"\(msg.method)\"")
+                }
+                return try parse(msg.payload)
+            }
+        }
+        throw UnisonError.notConnected
+    }
+
+    /// JSON payload を [`ServerIdentity`] へ。 channels は名前だけ抽出する。
+    static func parse(_ payload: Data) throws -> ServerIdentity {
+        struct WireIdentity: Decodable {
+            let name: String
+            let version: String
+            let namespace: String
+            struct WireChannel: Decodable { let name: String }
+            let channels: [WireChannel]
+        }
+        do {
+            let wire = try JSONDecoder().decode(WireIdentity.self, from: payload)
+            return ServerIdentity(
+                name: wire.name,
+                version: wire.version,
+                namespace: wire.namespace,
+                channels: wire.channels.map(\.name)
+            )
+        } catch {
+            throw UnisonError.codec("identity: ServerIdentity JSON parse 失敗: \(error)")
+        }
+    }
+}

--- a/clients/swift/Sources/UnisonClient/Internal/StreamChannelCore.swift
+++ b/clients/swift/Sources/UnisonClient/Internal/StreamChannelCore.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// stream channel の状態機械 (= TS `unison_channel.ts` の Swift port)。
+///
+/// 1 本の [`ChannelStream`] 上で:
+/// - **open**: `__channel:{name}` request → server の `__channel_ack` を await
+///   (response = accept / error = nack)。
+/// - **request/response**: id 採番して送信、 同 id の response/error を await。
+/// - **event**: server push (event/request msgType) を `eventStream` へ流す。
+///
+/// 受信は単一 recv loop。 `msgType` で pending request の resolve と event push を
+/// 振り分ける (= Rust `network/channel.rs` と同じ dispatch)。
+actor StreamChannelCore {
+    let name: String
+    private let stream: any ChannelStream
+
+    private var nextID: UInt64 = 1
+    private var pending: [UInt64: CheckedContinuation<Protocol_ProtocolMessage, Error>] = [:]
+    private var recvTask: Task<Void, Never>?
+    private var closed = false
+
+    /// server push event の生メッセージ列 (= 公開層が M.Event へ decode する)。
+    nonisolated let eventStream: AsyncStream<Protocol_ProtocolMessage>
+    private nonisolated let eventSink: AsyncStream<Protocol_ProtocolMessage>.Continuation
+
+    init(name: String, stream: any ChannelStream) {
+        self.name = name
+        self.stream = stream
+        let (s, c) = AsyncStream<Protocol_ProtocolMessage>.makeStream()
+        self.eventStream = s
+        self.eventSink = c
+    }
+
+    /// recv loop を起動する (= open / request の前に呼ぶ)。
+    func start() {
+        guard recvTask == nil else { return }
+        recvTask = Task { await self.recvLoop() }
+    }
+
+    /// `__channel:{name}` open handshake。 ack が error なら throw。
+    func open() async throws {
+        let id = allocID()
+        var msg = Protocol_ProtocolMessage()
+        msg.id = id
+        msg.method = "__channel:" + name
+        msg.msgType = .request
+        let ack = try await sendAndAwait(id: id, message: msg)
+        switch ack.msgType {
+        case .response:
+            return
+        case .error:
+            let reason = String(data: ack.payload, encoding: .utf8) ?? "open rejected"
+            throw UnisonError.channelRejected(channel: name, reason: reason)
+        default:
+            throw UnisonError.channelRejected(channel: name, reason: "unexpected ack msgType")
+        }
+    }
+
+    /// request を 1 本送り、 対応する response payload を返す。
+    func request(method: String, payload: Data) async throws -> Data {
+        let id = allocID()
+        var msg = Protocol_ProtocolMessage()
+        msg.id = id
+        msg.method = method
+        msg.msgType = .request
+        msg.payload = payload
+        let resp = try await sendAndAwait(id: id, message: msg)
+        if resp.msgType == .error {
+            throw UnisonError.transport(String(data: resp.payload, encoding: .utf8) ?? "request error")
+        }
+        return resp.payload
+    }
+
+    /// channel を閉じる (= pending を全 reject、 recv loop 停止、 stream close)。
+    func close() async {
+        guard !closed else { return }
+        closed = true
+        recvTask?.cancel()
+        failAll(UnisonError.notConnected)
+        await stream.close()
+    }
+
+    // MARK: - internal
+
+    private func allocID() -> UInt64 {
+        defer { nextID += 1 }
+        return nextID
+    }
+
+    /// pending を登録してから frame を送り、 id 対応の応答を待つ。
+    /// (ack が先着しても取りこぼさないよう、 send 前に pending 登録。)
+    private func sendAndAwait(
+        id: UInt64,
+        message: Protocol_ProtocolMessage
+    ) async throws -> Protocol_ProtocolMessage {
+        let frame = try Framing.encodeProtocolFrame(message)
+        return try await withCheckedThrowingContinuation { cont in
+            pending[id] = cont
+            Task {
+                do {
+                    try await stream.send(frame)
+                } catch {
+                    resumePending(id: id, throwing: error)
+                }
+            }
+        }
+    }
+
+    private func resumePending(id: UInt64, throwing error: Error) {
+        if let cont = pending.removeValue(forKey: id) {
+            cont.resume(throwing: error)
+        }
+    }
+
+    private func recvLoop() async {
+        var reader = FrameReader()
+        do {
+            while let chunk = try await stream.receive() {
+                reader.append(chunk)
+                while let body = try reader.nextFrame() {
+                    if case let .protocolMessage(msg) = try Framing.decodeFrameBody(body) {
+                        dispatch(msg)
+                    }
+                }
+            }
+        } catch {
+            failAll(error)
+            return
+        }
+        // EOF (stream 終端)。
+        failAll(UnisonError.notConnected)
+    }
+
+    private func dispatch(_ msg: Protocol_ProtocolMessage) {
+        switch msg.msgType {
+        case .response, .error:
+            // id 相関で pending を resolve (= open_ack / request response)。
+            if let cont = pending.removeValue(forKey: msg.id) {
+                cont.resume(returning: msg)
+            }
+        case .event, .request:
+            eventSink.yield(msg)
+        default:
+            break
+        }
+    }
+
+    private func failAll(_ error: Error) {
+        let conts = pending.values
+        pending.removeAll()
+        for cont in conts {
+            cont.resume(throwing: error)
+        }
+        eventSink.finish()
+    }
+}

--- a/clients/swift/Sources/UnisonClient/Transport/ChannelTransport.swift
+++ b/clients/swift/Sources/UnisonClient/Transport/ChannelTransport.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// 双方向 byte stream の抽象 (= TS `BidiStream` の Swift 対応物)。
+///
+/// NWProtocolQUIC の実 stream と in-memory test stream を同一 interface で扱い、
+/// channel mux / handshake / request-response のロジックを transport から切り離す
+/// (= 最もテストしたいプロトコル状態機械を、 QUIC の不確実性から独立させる)。
+public protocol ChannelStream: Sendable {
+    /// 完成した typed frame バイト列を 1 本送る。
+    func send(_ bytes: Data) async throws
+    /// 次の受信 chunk を返す。 EOF (stream 終端) なら nil。
+    func receive() async throws -> Data?
+    /// stream を閉じる。
+    func close() async
+}
+
+/// stream を開ける / 受け入れる接続の抽象 (= TS `Connection` の stream 部)。
+///
+/// - `openStream`: client 起点の bidi stream (= channel open / request 用)。
+/// - `acceptStream`: server 起点の bidi stream (= identity handshake 用)。
+public protocol ChannelTransport: Sendable {
+    /// client 起点の bidi stream を開く。
+    func openStream() async throws -> any ChannelStream
+    /// server 起点の bidi stream を 1 本受け入れる。 接続が閉じたら nil。
+    func acceptStream() async throws -> (any ChannelStream)?
+    /// transport を閉じる (= 接続切断)。
+    func close() async
+}

--- a/clients/swift/Sources/UnisonClient/Transport/QUICTransport.swift
+++ b/clients/swift/Sources/UnisonClient/Transport/QUICTransport.swift
@@ -6,7 +6,7 @@ import Security
 ///
 /// ALPN は `"unison"` 固定 (= Rust 側 `network::UNISON_ALPN` と一致。 QUIC は
 /// RFC 9001 §8.1 で ALPN 必須)。 framing / channel mux はこの上の層が担う。
-actor QUICTransport {
+actor QUICTransport: ChannelTransport {
     /// raw QUIC 経路の ALPN。 Rust `network::UNISON_ALPN` と一致させること。
     static let alpn = "unison"
 
@@ -57,6 +57,24 @@ actor QUICTransport {
 
     /// 接続を閉じる。
     func cancel() {
+        connection.cancel()
+    }
+
+    // MARK: - ChannelTransport 適合
+
+    /// client 起点の bidi QUIC stream を開く。
+    /// TODO(next pass): NWMultiplexGroup / NWConnectionGroup で stream を払い出す。
+    func openStream() async throws -> any ChannelStream {
+        throw UnisonError.notImplemented("QUICTransport.openStream (NWProtocolQUIC stream は次 pass)")
+    }
+
+    /// server 起点の bidi QUIC stream を受け入れる (= identity stream)。
+    /// TODO(next pass): group の newConnectionHandler から払い出す。
+    func acceptStream() async throws -> (any ChannelStream)? {
+        throw UnisonError.notImplemented("QUICTransport.acceptStream (NWProtocolQUIC stream は次 pass)")
+    }
+
+    func close() async {
         connection.cancel()
     }
 

--- a/clients/swift/Tests/UnisonClientTests/ChannelTests.swift
+++ b/clients/swift/Tests/UnisonClientTests/ChannelTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import UnisonClient
+
+// channel 状態機械の in-memory テスト (= NWProtocolQUIC 抜きで open / request-response
+// / event / identity の round-trip を決定論的に検証する)。
+
+private struct PingPongMeta: StreamChannelMeta {
+    static let name = "ping-pong"
+    struct Tick: Codable, Sendable, Equatable { let seq: Int }
+    typealias Event = Tick
+}
+
+private struct EchoReq: UnisonRequest {
+    static let method = "Echo"
+    struct Resp: Codable, Sendable, Equatable { let data: String }
+    typealias Response = Resp
+    let data: String
+}
+
+struct ChannelTests {
+    @Test func openChannelSucceedsOnAck() async throws {
+        let conn = Connection(transport: StubTransport())
+        let channel = try await conn.openChannel(PingPongMeta())
+        await channel.close()
+        // open が ack され throw しなければ成功。
+    }
+
+    @Test func openChannelRejectedOnNack() async throws {
+        let conn = Connection(transport: StubTransport(rejectOpen: true))
+        await #expect(throws: UnisonError.self) {
+            _ = try await conn.openChannel(PingPongMeta())
+        }
+    }
+
+    @Test func requestEchoRoundTrip() async throws {
+        let conn = Connection(transport: StubTransport())
+        let channel = try await conn.openChannel(PingPongMeta())
+        let resp = try await channel.request(EchoReq(data: "hello-unison"))
+        #expect(resp.data == "hello-unison")
+        await channel.close()
+    }
+
+    @Test func serverPushedEventArrives() async throws {
+        let tick = Data(#"{"seq":7}"#.utf8)
+        let conn = Connection(transport: StubTransport(pushEvents: [tick]))
+        let channel = try await conn.openChannel(PingPongMeta())
+        var received: PingPongMeta.Tick?
+        for await event in channel.events {
+            received = event
+            break
+        }
+        #expect(received == PingPongMeta.Tick(seq: 7))
+        await channel.close()
+    }
+
+    @Test func serverIdentityIsParsed() async throws {
+        let conn = Connection(transport: StubTransport())
+        let identity = try await conn.serverIdentity()
+        #expect(identity.name == "stub")
+        #expect(identity.version == "1.0.0")
+        #expect(identity.channels == ["ping-pong"])
+    }
+}

--- a/clients/swift/Tests/UnisonClientTests/InMemorySupport.swift
+++ b/clients/swift/Tests/UnisonClientTests/InMemorySupport.swift
@@ -1,0 +1,172 @@
+import Foundation
+@testable import UnisonClient
+
+/// 片方向 byte queue。 push / pop を continuation で繋ぐ (= AsyncIterator の actor
+/// 制約を避けるための最小実装)。
+actor InMemoryInbox {
+    private var buffer: [Data] = []
+    private var finished = false
+    private var waiter: CheckedContinuation<Data?, Never>?
+
+    func push(_ data: Data) {
+        if let w = waiter {
+            waiter = nil
+            w.resume(returning: data)
+        } else {
+            buffer.append(data)
+        }
+    }
+
+    func finish() {
+        finished = true
+        if let w = waiter {
+            waiter = nil
+            w.resume(returning: nil)
+        }
+    }
+
+    func pop() async -> Data? {
+        if !buffer.isEmpty { return buffer.removeFirst() }
+        if finished { return nil }
+        return await withCheckedContinuation { cont in waiter = cont }
+    }
+}
+
+/// in-memory な双方向 stream。 2 endpoint を memory pipe で繋ぐ (= TS `MockTransport`
+/// の Swift 版)。 NWProtocolQUIC 抜きで channel ロジックを決定論的にテストする。
+final class InMemoryStream: ChannelStream {
+    private let sendInbox: InMemoryInbox
+    private let readInbox: InMemoryInbox
+
+    init(sendTo: InMemoryInbox, readFrom: InMemoryInbox) {
+        self.sendInbox = sendTo
+        self.readInbox = readFrom
+    }
+
+    func send(_ bytes: Data) async throws {
+        await sendInbox.push(bytes)
+    }
+
+    func receive() async throws -> Data? {
+        await readInbox.pop()
+    }
+
+    func close() async {
+        await sendInbox.finish()
+    }
+}
+
+/// client / server 両端の `InMemoryStream` ペアを作る。
+enum InMemoryPair {
+    static func make() -> (client: InMemoryStream, server: InMemoryStream) {
+        let clientToServer = InMemoryInbox()
+        let serverToClient = InMemoryInbox()
+        let client = InMemoryStream(sendTo: clientToServer, readFrom: serverToClient)
+        let server = InMemoryStream(sendTo: serverToClient, readFrom: clientToServer)
+        return (client, server)
+    }
+}
+
+/// server 端の最小スタブ (= TS `StreamServerStub` の Swift 版)。
+///
+/// - `__channel:` open → `__channel_ack` (response = accept / `rejectOpen` 時は error)
+/// - request → echo (= 同 payload を response で返す)
+/// - open 直後に `pushEvents` を event frame として流す
+enum EchoServerStub {
+    static func serve(
+        _ stream: any ChannelStream,
+        rejectOpen: Bool = false,
+        pushEvents: [Data] = []
+    ) -> Task<Void, Never> {
+        Task {
+            var reader = FrameReader()
+            while let chunk = try? await stream.receive() {
+                reader.append(chunk)
+                while let body = nextBody(&reader) {
+                    guard case let .protocolMessage(msg)? = try? Framing.decodeFrameBody(body) else {
+                        continue
+                    }
+                    if msg.method.hasPrefix("__channel:") {
+                        var ack = Protocol_ProtocolMessage()
+                        ack.id = msg.id
+                        ack.method = "__channel_ack"
+                        ack.msgType = rejectOpen ? .error : .response
+                        if rejectOpen {
+                            ack.payload = Data(#"{"error":"channel-not-found"}"#.utf8)
+                        }
+                        await sendFrame(stream, ack)
+                        if !rejectOpen {
+                            for ev in pushEvents {
+                                var event = Protocol_ProtocolMessage()
+                                event.method = "event"
+                                event.msgType = .event
+                                event.payload = ev
+                                await sendFrame(stream, event)
+                            }
+                        }
+                    } else if msg.msgType == .request {
+                        var resp = Protocol_ProtocolMessage()
+                        resp.id = msg.id
+                        resp.method = msg.method
+                        resp.msgType = .response
+                        resp.payload = msg.payload // echo
+                        await sendFrame(stream, resp)
+                    }
+                }
+            }
+        }
+    }
+
+    /// identity stream を 1 本 push して finish する server 端。
+    static func serveIdentity(_ stream: any ChannelStream, json: String) -> Task<Void, Never> {
+        Task {
+            var msg = Protocol_ProtocolMessage()
+            msg.method = "__identity"
+            msg.msgType = .event
+            msg.payload = Data(json.utf8)
+            await sendFrame(stream, msg)
+            await stream.close()
+        }
+    }
+
+    private static func nextBody(_ reader: inout FrameReader) -> Data? {
+        (try? reader.nextFrame()) ?? nil
+    }
+
+    private static func sendFrame(_ stream: any ChannelStream, _ msg: Protocol_ProtocolMessage) async {
+        if let frame = try? Framing.encodeProtocolFrame(msg) {
+            try? await stream.send(frame)
+        }
+    }
+}
+
+/// client 側 transport。 openStream ごとに echo stub を server 端へ配する。
+final class StubTransport: ChannelTransport, @unchecked Sendable {
+    let rejectOpen: Bool
+    let pushEvents: [Data]
+    let identityJSON: String
+
+    init(
+        rejectOpen: Bool = false,
+        pushEvents: [Data] = [],
+        identityJSON: String = #"{"name":"stub","version":"1.0.0","namespace":"test","channels":[{"name":"ping-pong"}]}"#
+    ) {
+        self.rejectOpen = rejectOpen
+        self.pushEvents = pushEvents
+        self.identityJSON = identityJSON
+    }
+
+    func openStream() async throws -> any ChannelStream {
+        let (client, server) = InMemoryPair.make()
+        _ = EchoServerStub.serve(server, rejectOpen: rejectOpen, pushEvents: pushEvents)
+        return client
+    }
+
+    func acceptStream() async throws -> (any ChannelStream)? {
+        let (client, server) = InMemoryPair.make()
+        _ = EchoServerStub.serveIdentity(server, json: identityJSON)
+        return client
+    }
+
+    func close() async {}
+}

--- a/clients/swift/Tests/UnisonClientTests/UnisonClientTests.swift
+++ b/clients/swift/Tests/UnisonClientTests/UnisonClientTests.swift
@@ -25,13 +25,13 @@ import Testing
 // 例: consumer が定義する channel meta はこう書ける (= 生成 or 手書きの形)。
 private struct PingPongMeta: StreamChannelMeta {
     static let name = "ping-pong"
-    struct Tick: Sendable, Equatable {}
+    struct Tick: Codable, Sendable, Equatable {}
     typealias Event = Tick
 }
 
 private struct Ping: UnisonRequest {
     static let method = "Ping"
-    struct Pong: Sendable, Equatable { let reply: String }
+    struct Pong: Codable, Sendable, Equatable { let reply: String }
     typealias Response = Pong
     let message: String
 }


### PR DESCRIPTION
## 概要

Swift client SDK 次 pass その2a。transport を抽象化し、**channel mux + identity handshake + request/response** を in-memory test で決定論的に固める。

`抽象 → in-memory test → 実 adapter` の方針(前回合意)に沿い、最もテストしたいプロトコル状態機械を NWProtocolQUIC の不確実性から切り離して先に完成させる。

## 変更

- **抽象**: `ChannelStream`(双方向 byte stream)/ `ChannelTransport`(stream の open/accept)= TS `BidiStream` / `Connection` 相当
- **`StreamChannelCore`**: 単一 recv loop で `msgType` dispatch。`id` 相関の request/response(`CheckedContinuation`)、`__channel:` open→`__channel_ack`、event push
- **`IdentityHandshake`**: `__identity` stream を読んで `ServerIdentity` を parse(JSON)
- **`Connection`** を `ChannelTransport` 駆動に rewire(`openChannel` / `serverIdentity` を実装)
- **`StreamChannel.request<R>` / `events`** を JSON codec で実配線。`UnisonRequest: Encodable` / `Response,Event: Decodable` の制約を追加(wire は既定 JSON)

## 検証(in-memory、決定論的)

`InMemoryStream`(paired pipe)+ `EchoServerStub`(= TS `MockTransport`/`StreamServerStub` の Swift 版)で 17 tests green:

- ✅ `openChannelSucceedsOnAck` / `openChannelRejectedOnNack`(open→ack/nack)
- ✅ **`requestEchoRoundTrip`**(request/response round-trip = acceptance)
- ✅ `serverPushedEventArrives`(event push + `M.Event` decode)
- ✅ `serverIdentityIsParsed`(identity handshake)
- ✅ 既存 wire byte-compat 8 + scaffold smoke 4

## 次 pass(2b)

`QUICTransport.openStream` / `acceptStream`(実 NWProtocolQUIC stream adapter)をこの抽象に接続 → `unison mock` 相手の **live e2e**(Swift → quinn で実 echo round-trip)。`NWMultiplexGroup` / `NWConnectionGroup` での stream 払い出しが論点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)