### PR TITLE
docs(release): 1.3.0 release 整備 — CHANGELOG / Swift CI / docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,3 +222,24 @@ jobs:
       - name: Run TS test suite (incl. cross-lang E2E)
         working-directory: clients/typescript
         run: npm test
+
+  # ===========================================
+  # Swift client (clients/swift)
+  # ===========================================
+  # NWProtocolQUIC / swift-protobuf を使う SPM package。生成 wire コードは
+  # コミット済みなので protoc 不要。LiveE2ETests は UNISON_LIVE 環境変数で gate
+  # され (mock server 必須)、ここでは未設定なので skip される。
+  swift:
+    name: Swift Client
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: clients/swift
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build
+
+      - name: Test (live e2e は UNISON_LIVE gate で skip)
+        run: swift test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-25 — raw QUIC ALPN "unison" + Swift client SDK
+
+> Apple `NWProtocolQUIC` との interop のため raw QUIC に ALPN を追加し
+> (RFC 9001 §8.1 — QUIC は ALPN 必須)、Swift native client SDK (`clients/swift`)
+> を新設。SemVer minor (= additive)。raw QUIC は server/client 両端が同 label を
+> negotiate するため後方互換。
+
+### Added
+
+- **raw QUIC ALPN** (`network::UNISON_ALPN = "unison"`): server (`quic.rs`) /
+  client (`trust.rs` 全 trust mode) が ALPN を negotiate。空 ALPN で handshake
+  していた従来は QUIC 仕様逸脱で、Apple `NWProtocolQUIC` 等の厳格実装と interop
+  できなかった。WebTransport 経路は HTTP/3 の `"h3"` 固定 (別 ingress) で無影響。
+  PR: [#74](https://github.com/chronista-club/club-unison/pull/74)
+- **Swift client SDK** (`clients/swift` — new): Apple `Network.framework`
+  (`NWProtocolQUIC`) + `swift-protobuf`。`clients/{ruby,typescript}` の swift
+  sibling。stream channel (connect / openChannel / request-response / event /
+  identity handshake) が実 quinn server 相手に live e2e 済み。API は
+  `design/typescript-client-api.md` と同形式 (`AsyncStream` / `async throws` /
+  `actor`)。PR: [#75](https://github.com/chronista-club/club-unison/pull/75)–[#78](https://github.com/chronista-club/club-unison/pull/78)
+
+### Notes
+
+- Swift client の datagram channel / `Endpoint.bonjour` discovery / KDL→Swift
+  codegen は後続。現状 stream channel が GA。
+
+## [1.2.0] - 2026-06-18 — ProtocolServer cert 指定 spawn (federation API gap)
+
+> chronista-hub の world federation 要件で判明した API gap の解消。spawn 経路が
+> `dev_localhost` cert 固定で非 loopback 公開 (tailnet / public federation) が
+> できなかった問題を、cert 指定 spawn variant の追加で解決。SemVer minor (= additive)。
+
+### Added
+
+- `ProtocolServer::spawn_listen_with_cert` / `spawn_listen_shared_with_cert`:
+  `CertSource` を受ける spawn variant。`QuicServer::builder().cert_source()` を
+  経由し、非 loopback アドレスでの公開が可能に。既存 `spawn_listen` /
+  `spawn_listen_shared` は `dev_localhost` 既定へ委譲し後方互換維持。
+  PR: [#73](https://github.com/chronista-club/club-unison/pull/73)
+
 ## [1.1.0] - 2026-05-28 — Hailing α: runtime protocol discovery + AI-native MCP tools
 
 > Hailing α Epic の minor release。 `unison.discovery` channel で server が自身の

--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ cargo run -p unison-agent --example simple_query        # one-shot query
 cargo run -p unison-agent --example interactive_chat    # multi-turn conversation
 ```
 
+## Polyglot clients
+
+The server stays Rust; clients are first-class siblings under [`clients/`](https://github.com/chronista-club/club-unison/tree/main/clients). Wire-format conformance and protocol semantics are owned by this framework, so each client interops byte-for-byte with the Rust server.
+
+| Client | Transport | Distribution |
+|--------|-----------|--------------|
+| [`clients/typescript`](https://github.com/chronista-club/club-unison/tree/main/clients/typescript) | WebTransport (HTTP/3) | npm `@chronista-club/unison-client` |
+| [`clients/ruby`](https://github.com/chronista-club/club-unison/tree/main/clients/ruby) | raw QUIC (FFI → Rust) | RubyGems `unison-client` |
+| [`clients/swift`](https://github.com/chronista-club/club-unison/tree/main/clients/swift) | raw QUIC (Apple `NWProtocolQUIC`, ALPN `"unison"`) | SPM (monorepo path / git) — see note |
+
+> **Swift package consumption**: `clients/swift` の `Package.swift` は repo の
+> サブディレクトリにあり、SPM の version 指定 remote 依存 (`.package(url:from:)`)
+> は repo root の `Package.swift` を前提とするため使えない。consumer (例: VP) は
+> **path 依存** (`.package(path: "../club-unison/clients/swift")`、monorepo 隣接)
+> で参照する。将来 versioned 配布が要るなら別 repo 切り出しを検討。
+
 ---
 
 ## Development

--- a/design/quic-runtime.md
+++ b/design/quic-runtime.md
@@ -4,11 +4,22 @@
 
 本ドキュメントでは、Unison ProtocolにおけるQUIC Runtime統合の設計を記述する。QUICトランスポート層は以下の要素で構成される:
 
+- **ALPN**: raw QUIC は ALPN `"unison"` を negotiate（`network::UNISON_ALPN`）
 - **ConnectionContext**: 接続ごとの状態管理（identity、チャネル追跡）
 - **Identity Handshake**: 接続直後のサーバー自己紹介プロトコル
 - **チャネルルーティング**: `__channel:` プレフィックスによるチャネル多重化
 - **Length-Prefixed Framing**: 4バイトBE長プレフィックスによるフレーム境界
 - **UnisonChannel**: 統合チャネル型（request/response + event push）
+
+### ALPN（v1.3.0+）
+
+QUIC は仕様（RFC 9001 §8.1）で ALPN を必須とする。raw QUIC の server
+（`quic.rs`）と client（`trust.rs`）は SSOT である `network::UNISON_ALPN`
+（= `"unison"`）を negotiate する。空 ALPN は仕様逸脱であり、Apple
+`NWProtocolQUIC` 等の厳格実装（Swift client）と interop できないため v1.3.0 で
+明示設定した。server / client が同 label で合意するため Rust↔Rust / Ruby（FFI）は
+後方互換。WebTransport 経路は HTTP/3 上のため ALPN は `"h3"` 固定（`wtransport`
+依存が内部設定）で、本 const は適用されない（別 ingress）。
 
 全体のアーキテクチャ層における位置付け:
 

--- a/design/swift-client-api.md
+++ b/design/swift-client-api.md
@@ -1,0 +1,83 @@
+# design/swift-client-api.md — Swift Client SDK API Design
+
+**バージョン**: 0.1（v1.3.0 で stream channel GA）
+**最終更新**: 2026-06-25
+**ステータス**: Implemented（`clients/swift`）— stream channel が実 QUIC で動作
+
+---
+
+## 1. 目的
+
+`clients/{ruby,typescript}` の swift sibling として、Apple platform 面（macOS
+menu bar agent / visionOS app）が Unison server に **pure Apple-native Swift** で
+接続するための generic client SDK。VP 非依存。wire-format conformance / protocol
+semantics / version 互換は本 framework が owns し、consumer（VP の `VPProtocol`
+等）は app 固有 channel meta を載せるだけにする。
+
+設計は `design/typescript-client-api.md` の ideal-caller-first を踏襲（同形式・同体験）。
+
+## 2. transport / wire
+
+| 層 | 実装 |
+|----|------|
+| transport | Apple `Network.framework` の `NWProtocolQUIC`（生 QUIC: streams + datagrams, TLS1.3） |
+| stream 多重化 | `NWMultiplexGroup` + `NWConnectionGroup`（client 起点 = `NWConnection(from:)`、server 起点 = `newConnectionHandler`） |
+| ALPN | `"unison"` 固定 = Rust `network::UNISON_ALPN`（QUIC は RFC 9001 §8.1 で ALPN 必須、Apple は強制） |
+| wire | `proto/protocol.proto` → `swift-protobuf` 生成（`Protocol_PacketHeader` / `Protocol_ProtocolMessage`） |
+| framing | typed frame `[4B BE len][1B type][UnisonPacket]`（Rust `quic.rs` と byte 一致、golden fixture 検証済み） |
+
+## 3. API contract
+
+```swift
+public enum UnisonClient {
+    public static func connect(to: Endpoint, trust: TrustPolicy) async throws -> Connection
+}
+public enum Endpoint    { case localDaemon(port: UInt16), host(String, port: UInt16), bonjour(String) }
+public enum TrustPolicy { case system, skipVerify, pinned(Data) }
+
+public actor Connection {
+    public nonisolated var connectionEvents: AsyncStream<ConnectionEvent> { get }  // reconnect は caller 責務
+    public func serverIdentity() async throws -> ServerIdentity
+    public func openChannel<M: StreamChannelMeta>(_ meta: M) async throws -> StreamChannel<M>
+    public func openDatagramChannel<M: DatagramChannelMeta>(_ meta: M) async throws -> DatagramChannel<M>
+    public func disconnect() async
+}
+public struct StreamChannel<M: StreamChannelMeta>: Sendable {
+    public var events: AsyncStream<M.Event> { get }
+    public func request<R: UnisonRequest>(_ req: R) async throws -> R.Response
+    public func close() async
+}
+```
+
+idiom mapping: `AsyncIterable`→`AsyncStream`、`Promise`→`async throws`、生成
+`ChannelMeta`→Swift generic + 生成型、actor で接続状態を隔離。
+
+## 4. 設計判断
+
+- **`request<R: M.Request>` → `request<R: UnisonRequest>`**: handoff sketch は
+  associatedtype `M.Request` を generic constraint に使う形だったが、Swift は
+  associatedtype を制約に使えないため `UnisonRequest` プロトコル制約へ置換。caller
+  体験（`channel.request(SomeReq(...))`）は不変。
+- **JSON codec 既定**: `UnisonRequest: Encodable` / `Response, Event: Decodable`。
+  wire payload は TS と同じ既定 JSON codec。
+- **reconnect は caller 責務**（library は auto-reconnect しない、TS と同方針）。
+- **transport 抽象**: `ChannelStream` / `ChannelTransport` を挟み、channel 状態機械
+  （open / request-response / event / identity）を NWProtocolQUIC から分離。in-memory
+  paired stream で決定論的にテストし、実 stream は薄い adapter で接続（= TS の
+  `MockTransport` / `StreamServerStub` と同じテスト構造）。
+
+## 5. codegen 2 層
+
+1. **wire**: `protocol.proto` → swift-protobuf（生成物はコミット、consumer は protoc 不要）
+2. **app**: KDL schema → Swift channel meta + 型（当面手書き、将来 KDL→Swift codegen）。
+   consumer の `VPProtocol`（`vp-world.kdl`→Swift）は VP repo 側に置く。
+
+## 6. 実装状況 / 残り
+
+GA: stream channel（connect / openChannel / request-response / event / identity）。
+`unison mock`（quinn）相手の live e2e PASS。
+
+残り（後続 pass）: `DatagramChannel`（QUIC datagram demux）/ `Endpoint.bonjour`
+discovery / KDL→Swift channel-meta codegen。
+
+> 実装詳細・ビルド・live e2e 手順は [`clients/swift/README.md`](../clients/swift/README.md)。


### PR DESCRIPTION
## 概要

1.3.0 リリース(ALPN #74 + Swift client #75–78)の release hygiene。リリース前の「抜け」を埋める。

## 変更

- **CHANGELOG**: 2版分遅れていたのを解消
  - `[1.2.0]` cert spawn(#73)
  - `[1.3.0]` raw QUIC ALPN `"unison"`(#74)+ Swift client SDK(#75–78)
- **CI**: `clients/swift` の **Swift job 追加**(macos-latest、`swift build` + `swift test`)。生成 wire コードはコミット済みで protoc 不要、`LiveE2ETests` は `UNISON_LIVE` gate で CI では skip。これまで Swift client は CI 無しだった
- **README**: Polyglot clients セクション追加(ruby / typescript / swift)。Swift の **SPM 消費は path 依存**(サブディレクトリ package は version 指定 remote 依存不可)の注記
- **design/quic-runtime.md**: ALPN `"unison"`(`network::UNISON_ALPN`)の節を追加
- **design/swift-client-api.md**(new): Swift client の API contract + 設計判断(`request<R: UnisonRequest>` への置換理由、transport 抽象、JSON codec 既定 等)

## 検証

- [x] `swift build` + `swift test` 18 tests green(local)
- [x] `cargo publish -p club-unison --dry-run`(1.3.0、clean state で通ることを merge 後確認 → publish)

## リリース手順(本 PR merge 後)

1. tag `v1.3.0` 作成 + push
2. `cargo publish -p club-unison`(crates.io 1.2.0 → 1.3.0)

> version は #74 で既に 1.3.0 に bump 済み(クレート本体は以降不変、Swift は別 artifact)。本 PR は docs/CI のみで version 変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)