### PR TITLE
feat(auth): connection-level auth primitive (mechanism/policy 分離)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-27 — connection-level auth primitive (mechanism/policy 分離)
+
+> 全エンドポイント間通信 (federation worlds channel / 連邦 wire / live streaming) の認証を
+> connection 確立時に1回行う primitive を追加。authN を connection に、authZ を per-message
+> に分離し per-frame 0 bytes。mechanism (= club-unison) と policy (= app の verifier) を分離
+> し、library は特定の認証エコシステムに依存しない (OSS ecosystem-neutral)。SemVer minor
+> (= additive、opt-in、既存 API 不変・非破壊)。
+
 ### Added
 
 - **connection-level auth primitive** (`network::auth` — new): 全エンドポイント間通信

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@
 
 ## [Unreleased]
 
+### Added
+
+- **connection-level auth primitive** (`network::auth` — new): 全エンドポイント間通信
+  (federation worlds channel / 連邦 wire / live streaming) の認証を **connection 確立時に
+  1 回** 行う primitive。authN を connection に、authZ を per-message (`ctx.principal()` を
+  引く app 側 gate) に分離し、**per-frame に auth byte 0**。live streaming の小フレーム
+  fan-out / datagram を auth コストで殺さないための設計。SemVer minor (= additive、opt-in)。
+  - `ProtocolServer::enable_auth(verifier)`: `enable_discovery` と同型の opt-in API。
+    reserved channel `unison.auth` を登録。verifier (= app 注入の policy) は async
+    (`Fn(Vec<u8>) -> Future<Option<Principal>>`)。
+  - `ProtocolClient::connect_with_credential(url, credential)`: 接続直後に credential を
+    1 回提示して認証する helper。
+  - `ConnectionContext::{set_principal, principal}` + `Principal = Arc<dyn Any + Send + Sync>`:
+    認証済み client の **opaque** な principal を connection に保持。app が downcast する。
+  - **mechanism / policy 分離** (`cert::CertSource` 哲学の踏襲): library は credential /
+    principal の中身 (Creo ID JWT 等) を一切解釈しない → 特定の認証エコシステムに依存
+    しない (= OSS として ecosystem-neutral)。`enable_auth` を呼ばない server は従来通り
+    (非破壊)。
+  - 設計: `design/connection-auth.md` / E2E: `tests/test_integ_auth.rs` (4 ケース)。
+
 ## [1.3.0] - 2026-06-25 — raw QUIC ALPN "unison" + Swift client SDK
 
 > Apple `NWProtocolQUIC` との interop のため raw QUIC に ALPN を追加し

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/crates/unison-protocol/src/network/auth.rs
+++ b/crates/unison-protocol/src/network/auth.rs
@@ -1,0 +1,210 @@
+//! Auth channel handler — server-side handler for `unison.auth`.
+//!
+//! 役割: connection 確立直後に client が提示する credential を1回受け取り、
+//! app 注入の [`Verifier`] に渡し、 成功なら [`Principal`] を
+//! [`ConnectionContext`] に立てる (= connection-level authN)。
+//!
+//! authZ (= per-message scope check) は app 側の責務。各 channel handler が
+//! [`ConnectionContext::principal`] を引いて gate する (= mechanism/policy 分離)。
+//!
+//! # mechanism / policy 分離
+//!
+//! - **mechanism = このモジュール**: credential を受け取り verifier に渡し principal を
+//!   立てる配管。credential / principal の中身は一切解釈しない (= opaque)。
+//! - **policy = app (operator)**: [`Verifier`] を注入。Creo ID JWKS でも静的 API キーでも
+//!   独自トークンでも良い。これにより library は特定の認証エコシステムに依存しない
+//!   ([`super::cert::CertSource`] が trust model を選ばないのと同型)。
+//!
+//! 設計: `design/connection-auth.md`
+//! KDL: `schemas/auth.kdl`
+//!
+//! # 典型使用 (server 側)
+//!
+//! ```ignore
+//! let server = ProtocolServer::new();
+//! server.enable_auth(|credential: Vec<u8>| async move {
+//!     // app の policy: credential を検証して principal を返す
+//!     (credential == b"secret-token")
+//!         .then(|| std::sync::Arc::new(MyUser::admin()) as Principal)
+//! }).await;
+//! // 以降、 client は connect_with_credential(addr, cred) で認証し、
+//! // 各 channel handler は ctx.principal() で authZ gate する。
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use super::context::{ConnectionContext, Principal};
+use super::quic::UnisonStream;
+use super::{MessageType, NetworkError, UnisonChannel};
+
+/// `unison.auth` channel name (= `schemas/auth.kdl` 側と一致)
+pub const AUTH_CHANNEL_NAME: &str = "unison.auth";
+
+/// `Authenticate` request method name (= `schemas/auth.kdl` 側と一致)
+pub const AUTHENTICATE_METHOD: &str = "Authenticate";
+
+/// `Authenticate` request payload (client → server)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthenticateRequest {
+    /// opaque な credential bytes (= 例 Creo ID JWT、 API キー、 独自トークン)。
+    /// library は中身を解釈せず verifier にそのまま渡す。
+    pub credential: Vec<u8>,
+}
+
+/// `AuthResult` response payload (server → client)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthResult {
+    /// verifier が principal を返した (= 認証成功) なら true。
+    pub ok: bool,
+}
+
+/// app 注入の認証 verifier (= policy)。
+///
+/// credential bytes を受け取り、 認証成功なら [`Principal`] を、 失敗なら `None` を返す。
+/// async — Creo ID JWKS の cache miss など network fetch を伴う検証を許容する。
+///
+/// credential は所有権ごと渡される (= async block へ move できる)。返す future は
+/// `'static` (= boxed) なので、 verifier は credential を借用したまま future に
+/// 抱え込めない (所有権を move すること)。
+pub type Verifier =
+    Arc<dyn Fn(Vec<u8>) -> Pin<Box<dyn Future<Output = Option<Principal>> + Send>> + Send + Sync>;
+
+/// `unison.auth` channel handler loop。
+///
+/// 1 connection 毎に 1 回起動され、 channel が close するまで request を待ち受ける。
+/// `Authenticate` request に対して verifier を呼び、 成功なら `ctx` に principal を立てて
+/// `AuthResult { ok: true }` を、 失敗なら `AuthResult { ok: false }` を返す (principal は
+/// None のまま)。他 method / event は debug log を吐いて無視する (= forward-compat)。
+///
+/// `ctx` は **connection 単位で全 channel handler と共有** される ([`super::dispatch`] が
+/// `Arc::clone` で配る) ため、 ここで立てた principal を worlds/wire/datagram handler が
+/// 読める。
+pub async fn handle_channel(
+    verifier: Verifier,
+    ctx: Arc<ConnectionContext>,
+    stream: UnisonStream,
+) -> Result<(), NetworkError> {
+    let channel = UnisonChannel::new(stream);
+    loop {
+        match channel.recv().await {
+            Ok(msg) if msg.msg_type == MessageType::Request => {
+                if msg.method == AUTHENTICATE_METHOD {
+                    let credential = match msg.payload_as_value() {
+                        Ok(value) => match serde_json::from_value::<AuthenticateRequest>(value) {
+                            Ok(req) => req.credential,
+                            Err(e) => {
+                                // malformed payload は認証拒否 (= verifier に渡さない)。
+                                tracing::debug!(error = %e, "auth: malformed Authenticate payload");
+                                channel
+                                    .send_response(
+                                        msg.id,
+                                        AUTHENTICATE_METHOD,
+                                        &serde_json::to_value(AuthResult { ok: false })?,
+                                    )
+                                    .await?;
+                                continue;
+                            }
+                        },
+                        Err(e) => {
+                            tracing::debug!(error = %e, "auth: non-JSON Authenticate payload");
+                            channel
+                                .send_response(
+                                    msg.id,
+                                    AUTHENTICATE_METHOD,
+                                    &serde_json::to_value(AuthResult { ok: false })?,
+                                )
+                                .await?;
+                            continue;
+                        }
+                    };
+
+                    let principal = verifier(credential).await;
+                    let ok = principal.is_some();
+                    if let Some(p) = principal {
+                        ctx.set_principal(p).await;
+                    }
+                    channel
+                        .send_response(
+                            msg.id,
+                            AUTHENTICATE_METHOD,
+                            &serde_json::to_value(AuthResult { ok })?,
+                        )
+                        .await?;
+
+                    tracing::debug!(ok, "auth: served Authenticate");
+                } else {
+                    tracing::warn!(
+                        method = %msg.method,
+                        "auth: unknown request method, ignoring (= forward-compat)"
+                    );
+                }
+            }
+            Ok(msg) => {
+                tracing::debug!(
+                    method = %msg.method,
+                    msg_type = ?msg.msg_type,
+                    "auth: ignored non-request"
+                );
+            }
+            Err(e) if e.is_normal_close() => return Ok(()),
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// const が schemas/auth.kdl と一致していることの guard test。
+    /// schemas を編集したら必ずこの test も更新する。
+    #[test]
+    fn auth_names_match_kdl_schema() {
+        assert_eq!(AUTH_CHANNEL_NAME, "unison.auth");
+        assert_eq!(AUTHENTICATE_METHOD, "Authenticate");
+    }
+
+    /// AuthenticateRequest の JSON serde round-trip
+    #[test]
+    fn authenticate_request_serde_round_trip() {
+        let req = AuthenticateRequest {
+            credential: b"creo-id-jwt".to_vec(),
+        };
+        let value = serde_json::to_value(&req).unwrap();
+        let restored: AuthenticateRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(restored.credential, req.credential);
+    }
+
+    /// AuthResult の JSON serde round-trip
+    #[test]
+    fn auth_result_serde_round_trip() {
+        for ok in [true, false] {
+            let value = serde_json::to_value(AuthResult { ok }).unwrap();
+            let restored: AuthResult = serde_json::from_value(value).unwrap();
+            assert_eq!(restored.ok, ok);
+        }
+    }
+
+    /// Verifier の async closure が credential を所有権ごと受け取り principal を返せる
+    #[tokio::test]
+    async fn verifier_async_closure_returns_principal() {
+        let verifier: Verifier = Arc::new(|cred: Vec<u8>| {
+            Box::pin(async move {
+                (cred == b"good").then(|| Arc::new("alice".to_string()) as Principal)
+            })
+        });
+
+        let ok = verifier(b"good".to_vec()).await;
+        assert!(ok.is_some());
+        assert_eq!(
+            ok.unwrap().downcast_ref::<String>().map(String::as_str),
+            Some("alice")
+        );
+
+        let denied = verifier(b"bad".to_vec()).await;
+        assert!(denied.is_none());
+    }
+}

--- a/crates/unison-protocol/src/network/client.rs
+++ b/crates/unison-protocol/src/network/client.rs
@@ -358,6 +358,47 @@ impl ProtocolClient {
         Ok(())
     }
 
+    /// Unisonサーバーへ接続し、 接続直後に credential を1回提示して認証する
+    /// (= connection-level authN)。
+    ///
+    /// [`connect`](Self::connect) → `unison.auth` channel を open → `Authenticate`
+    /// request で credential を送り、 server の verifier 結果を待つ。認証が拒否された
+    /// (= `AuthResult { ok: false }`) 場合は [`NetworkError::Protocol`] で reject する。
+    ///
+    /// 認証成功後、 server 側はこの connection の principal を立てているので、 以降
+    /// open する worlds/wire/datagram 等の channel は per-message gate を通過できる。
+    /// **他 channel を open する前に本メソッドを呼ぶこと** (= 未認証だと principal=None で
+    /// app handler に gate される)。
+    ///
+    /// server が `enable_auth` を呼んでいない場合は `unison.auth` が未登録のため open が
+    /// reject される。認証不要の server には [`connect`](Self::connect) を使う。
+    ///
+    /// 設計: `design/connection-auth.md`
+    pub async fn connect_with_credential(
+        &self,
+        url: &str,
+        credential: &[u8],
+    ) -> Result<(), NetworkError> {
+        self.connect(url).await?;
+
+        let channel = self.open_channel(super::auth::AUTH_CHANNEL_NAME).await?;
+        let response: serde_json::Value = channel
+            .request(
+                super::auth::AUTHENTICATE_METHOD,
+                &serde_json::json!({ "credential": credential }),
+            )
+            .await?;
+        let result: super::auth::AuthResult = serde_json::from_value(response)?;
+        let _ = channel.close().await;
+
+        if !result.ok {
+            return Err(NetworkError::Protocol(
+                "authentication denied by server verifier".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Connection の `closed()` future を await して Disconnected event を fire する task
     /// を spawn (v0.10.0 Step 2)
     ///

--- a/crates/unison-protocol/src/network/context.rs
+++ b/crates/unison-protocol/src/network/context.rs
@@ -3,12 +3,25 @@
 //! 各接続に対して、Identity情報とアクティブチャネルを追跡する。
 //! 複数のストリームハンドラーから並行アクセスされるため Arc<RwLock<>> で保護。
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use super::identity::{ChannelDirection, ServerIdentity};
+
+/// 認証済み client の principal。
+///
+/// connection-level auth (= `unison.auth` channel) で verifier が返した値を保持する。
+/// **opaque** — このライブラリは中身の型を一切解釈しない。policy (= app) が
+/// [`ConnectionContext::principal`] で取り出して `downcast_ref::<MyPrincipal>()` する。
+///
+/// この opacity が、ライブラリが特定の認証エコシステム (Creo ID / JWKS 等) に
+/// 依存しないことを型レベルで保証する (= mechanism/policy 分離、`cert::CertSource` と同型)。
+///
+/// 設計: `design/connection-auth.md`
+pub type Principal = Arc<dyn Any + Send + Sync>;
 
 /// 接続ごとの状態を管理する構造体
 #[derive(Debug)]
@@ -19,6 +32,12 @@ pub struct ConnectionContext {
     identity: Arc<RwLock<Option<ServerIdentity>>>,
     /// アクティブなチャネルのマップ（チャネル名 → ハンドル）
     channels: Arc<RwLock<HashMap<String, ChannelHandle>>>,
+    /// 認証済み client principal（未認証なら None）。
+    ///
+    /// `unison.auth` handler が verifier の結果を [`set_principal`](Self::set_principal) で
+    /// 立て、 worlds/wire/datagram 等 **同一 connection の全 channel handler** が
+    /// [`principal`](Self::principal) で読んで authZ gate に使う。
+    principal: Arc<RwLock<Option<Principal>>>,
 }
 
 /// チャネルのメタデータ
@@ -36,6 +55,7 @@ impl ConnectionContext {
             connection_id: Uuid::new_v4(),
             identity: Arc::new(RwLock::new(None)),
             channels: Arc::new(RwLock::new(HashMap::new())),
+            principal: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -48,6 +68,20 @@ impl ConnectionContext {
     /// Identity情報を取得
     pub async fn identity(&self) -> Option<ServerIdentity> {
         self.identity.read().await.clone()
+    }
+
+    /// 認証済み principal を設定する（`unison.auth` handler が verifier 成功時に呼ぶ）。
+    pub async fn set_principal(&self, principal: Principal) {
+        let mut guard = self.principal.write().await;
+        *guard = Some(principal);
+    }
+
+    /// 認証済み principal を取得する（未認証なら None）。
+    ///
+    /// app handler は `ctx.principal().await.and_then(|p| p.downcast_ref::<T>().cloned())`
+    /// のように自分の型へ downcast して authZ gate に使う。
+    pub async fn principal(&self) -> Option<Principal> {
+        self.principal.read().await.clone()
     }
 
     /// チャネルを登録
@@ -90,6 +124,35 @@ mod tests {
         let ctx = ConnectionContext::new();
         assert!(ctx.identity().await.is_none());
         assert!(ctx.channel_names().await.is_empty());
+        assert!(ctx.principal().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_principal_set_and_downcast() {
+        #[derive(Debug, PartialEq)]
+        struct MyPrincipal {
+            user_id: String,
+        }
+
+        let ctx = ConnectionContext::new();
+        // 未認証は None
+        assert!(ctx.principal().await.is_none());
+
+        // opaque な型を set
+        ctx.set_principal(Arc::new(MyPrincipal {
+            user_id: "alice".to_string(),
+        }))
+        .await;
+
+        // app は自分の型へ downcast して取り出せる
+        let principal = ctx.principal().await.expect("principal should be set");
+        let typed = principal
+            .downcast_ref::<MyPrincipal>()
+            .expect("downcast should succeed");
+        assert_eq!(typed.user_id, "alice");
+
+        // 異なる型への downcast は失敗する（opacity の確認）
+        assert!(principal.downcast_ref::<String>().is_none());
     }
 
     #[tokio::test]

--- a/crates/unison-protocol/src/network/mod.rs
+++ b/crates/unison-protocol/src/network/mod.rs
@@ -42,9 +42,9 @@ pub mod webtransport;
 pub use auth::{AUTH_CHANNEL_NAME, AUTHENTICATE_METHOD, AuthResult, AuthenticateRequest, Verifier};
 pub use cert::CertSource;
 pub use channel::UnisonChannel;
-pub use context::Principal;
 pub use client::{ClientConnectionEvent, ClientConnectionEventReceiver, ProtocolClient};
 pub use conn::UnisonConn;
+pub use context::Principal;
 pub use datagram_channel::DatagramChannel;
 pub use discovery::{
     DISCOVERY_CHANNEL_NAME, GET_PROTOCOL_METHOD, GetProtocolRequest, ProtocolDocument,

--- a/crates/unison-protocol/src/network/mod.rs
+++ b/crates/unison-protocol/src/network/mod.rs
@@ -16,6 +16,7 @@ use crate::proto;
 /// 固定 (`wtransport` 依存が内部で設定) であり、 本 const は適用されない。
 pub const UNISON_ALPN: &[u8] = b"unison";
 
+pub mod auth;
 pub mod cert;
 pub mod channel;
 pub mod client;
@@ -38,8 +39,10 @@ pub mod stream;
 pub mod trust;
 pub mod webtransport;
 
+pub use auth::{AUTH_CHANNEL_NAME, AUTHENTICATE_METHOD, AuthResult, AuthenticateRequest, Verifier};
 pub use cert::CertSource;
 pub use channel::UnisonChannel;
+pub use context::Principal;
 pub use client::{ClientConnectionEvent, ClientConnectionEventReceiver, ProtocolClient};
 pub use conn::UnisonConn;
 pub use datagram_channel::DatagramChannel;

--- a/crates/unison-protocol/src/network/server.rs
+++ b/crates/unison-protocol/src/network/server.rs
@@ -261,6 +261,51 @@ impl ProtocolServer {
         Ok(())
     }
 
+    /// connection-level 認証を有効化する (= `unison.auth` channel を登録)。
+    ///
+    /// client が接続直後に `unison.auth` を open して credential を1回提示すると、
+    /// `verifier` (= app 注入の policy) で検証し、 成功なら principal を **その connection の
+    /// [`ConnectionContext`](super::context::ConnectionContext)** に立てる。以降、 各 channel
+    /// handler は `ctx.principal()` を引いて authZ gate できる (= per-message scope check、
+    /// per-frame に auth byte 0)。
+    ///
+    /// `enable_discovery` と同型の opt-in API。呼ばなければ認証は無効 (= 従来通り・非破壊)。
+    ///
+    /// # mechanism / policy 分離
+    /// このメソッドは「credential を受け取り verifier に渡し principal を立てる」配管
+    /// (= mechanism) のみを提供する。credential / principal の中身 (Creo ID JWT 等) は
+    /// `verifier` (= policy) が解釈し、 library は一切関知しない
+    /// ([`CertSource`](super::cert::CertSource) が trust model を選ばないのと同型)。
+    ///
+    /// 設計: `design/connection-auth.md`
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let server = ProtocolServer::new();
+    /// server.enable_auth(|credential: Vec<u8>| async move {
+    ///     verify_creo_id(&credential).await   // app の policy
+    ///         .map(|user| std::sync::Arc::new(user) as Principal)
+    /// }).await;
+    /// ```
+    pub async fn enable_auth<V, Fut>(&self, verifier: V)
+    where
+        V: Fn(Vec<u8>) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Option<super::context::Principal>> + Send + 'static,
+    {
+        let verifier: super::auth::Verifier = Arc::new(move |credential| {
+            Box::pin(verifier(credential))
+                as std::pin::Pin<
+                    Box<dyn std::future::Future<Output = Option<super::context::Principal>> + Send>,
+                >
+        });
+        self.register_channel(super::auth::AUTH_CHANNEL_NAME, move |ctx, stream| {
+            let verifier = Arc::clone(&verifier);
+            async move { super::auth::handle_channel(verifier, ctx, stream).await }
+        })
+        .await;
+    }
+
     /// チャネルハンドラーを登録
     pub async fn register_channel<F, Fut>(&self, name: &str, handler: F)
     where

--- a/crates/unison-protocol/tests/test_integ_auth.rs
+++ b/crates/unison-protocol/tests/test_integ_auth.rs
@@ -1,0 +1,207 @@
+//! Large × E2E: connection-level auth primitive (`unison.auth`) round-trip
+//!
+//! Server に [`ProtocolServer::enable_auth`] で verifier (= policy) を注入して起動し、
+//! client が credential を提示して認証 → 以降の channel が `ctx.principal()` で
+//! authZ gate されることを実 QUIC stack 上で確認する。
+//!
+//! 設計: `design/connection-auth.md`
+//! SSOT memory: mem_1CcTT4yxguA1KjGJXXHFor / handoff: mem_1CcTTLKuuTYGfATSKdSo8J
+//!
+//! すべて `#[ignore = "Large: E2E test"]` 付き — `cargo test -- --ignored` で実行。
+
+use anyhow::Result;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::timeout;
+
+use unison::network::channel::UnisonChannel;
+use unison::network::{MessageType, Principal, ProtocolClient, ProtocolServer, ServerHandle};
+
+const GOOD_TOKEN: &[u8] = b"good-token";
+const SECRET_CHANNEL: &str = "secret";
+
+/// app の principal 型 (= policy 側が定義、 library は知らない opaque 値)
+#[derive(Debug, Clone)]
+struct TestUser {
+    name: String,
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_test_writer()
+        .try_init();
+}
+
+/// gated channel handler: `ctx.principal()` を引いて authZ gate する (= per-message)。
+/// 認証済みなら principal の名前を返し、 未認証なら "unauthenticated" を返す。
+async fn handle_secret(
+    ctx: Arc<unison::network::context::ConnectionContext>,
+    stream: unison::network::UnisonStream,
+) -> Result<(), unison::network::NetworkError> {
+    let channel = UnisonChannel::new(stream);
+    loop {
+        match channel.recv().await {
+            Ok(msg) if msg.msg_type == MessageType::Request => {
+                // app 側の downcast (= mechanism は opaque を渡すだけ)
+                let user = ctx
+                    .principal()
+                    .await
+                    .and_then(|p| p.downcast_ref::<TestUser>().map(|u| u.name.clone()));
+                let payload = match user {
+                    Some(name) => json!({ "authed": true, "whoami": name }),
+                    None => json!({ "authed": false }),
+                };
+                channel.send_response(msg.id, &msg.method, &payload).await?;
+            }
+            Ok(_) => {}
+            Err(e) if e.is_normal_close() => return Ok(()),
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// verifier (= policy): GOOD_TOKEN だけ通し、 TestUser principal を返す。
+async fn start_auth_server() -> Result<(ServerHandle, String)> {
+    let server = ProtocolServer::with_identity("test-auth-srv", "0.1.0", "test");
+    server
+        .enable_auth(|credential: Vec<u8>| async move {
+            (credential == GOOD_TOKEN)
+                .then(|| Arc::new(TestUser { name: "alice".into() }) as Principal)
+        })
+        .await;
+    server.register_channel(SECRET_CHANNEL, handle_secret).await;
+    let handle = server.spawn_listen("[::1]:0").await?;
+    let addr = handle.local_addr();
+    Ok((handle, format!("[{}]:{}", addr.ip(), addr.port())))
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 1: 正当 credential → principal set → gated method 通過
+// ─────────────────────────────────────────────────────────────────────
+#[tokio::test]
+#[ignore = "Large: E2E test"]
+async fn test_e2e_auth_valid_credential_passes_gate() -> Result<()> {
+    init_tracing();
+    let (handle, addr) = start_auth_server().await?;
+
+    let client = ProtocolClient::new_default()?;
+    client.connect_with_credential(&addr, GOOD_TOKEN).await?;
+
+    let channel = client.open_channel(SECRET_CHANNEL).await?;
+    let resp: Value = timeout(
+        Duration::from_secs(5),
+        channel.request("GetSecret", &json!({})),
+    )
+    .await??;
+
+    assert_eq!(resp["authed"], json!(true), "authed should be true");
+    assert_eq!(resp["whoami"], json!("alice"), "principal name should leak through downcast");
+
+    channel.close().await?;
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 2: 不正 credential → connect_with_credential が拒否される
+// ─────────────────────────────────────────────────────────────────────
+#[tokio::test]
+#[ignore = "Large: E2E test"]
+async fn test_e2e_auth_invalid_credential_rejected() -> Result<()> {
+    init_tracing();
+    let (handle, addr) = start_auth_server().await?;
+
+    let client = ProtocolClient::new_default()?;
+    let result = client.connect_with_credential(&addr, b"wrong-token").await;
+
+    assert!(
+        result.is_err(),
+        "invalid credential should be rejected by verifier"
+    );
+
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 3: 未認証 (plain connect) → principal None → gated method が拒否反応
+// ─────────────────────────────────────────────────────────────────────
+#[tokio::test]
+#[ignore = "Large: E2E test"]
+async fn test_e2e_auth_unauthenticated_is_gated() -> Result<()> {
+    init_tracing();
+    let (handle, addr) = start_auth_server().await?;
+
+    // credential を出さず素の connect → principal は立たない
+    let client = ProtocolClient::new_default()?;
+    client.connect(&addr).await?;
+
+    let channel = client.open_channel(SECRET_CHANNEL).await?;
+    let resp: Value = timeout(
+        Duration::from_secs(5),
+        channel.request("GetSecret", &json!({})),
+    )
+    .await??;
+
+    assert_eq!(
+        resp["authed"],
+        json!(false),
+        "unauthenticated connection should be gated (principal None)"
+    );
+
+    channel.close().await?;
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 4: enable_auth を呼ばない server は従来通り動く (= opt-in、 非破壊)
+// ─────────────────────────────────────────────────────────────────────
+#[tokio::test]
+#[ignore = "Large: E2E test"]
+async fn test_e2e_no_enable_auth_is_nonbreaking() -> Result<()> {
+    init_tracing();
+
+    // enable_auth 無し。通常 channel のみ。
+    let server = ProtocolServer::with_identity("test-noauth-srv", "0.1.0", "test");
+    server
+        .register_channel("echo", |_ctx, stream| async move {
+            let channel = UnisonChannel::new(stream);
+            loop {
+                match channel.recv().await {
+                    Ok(msg) if msg.msg_type == MessageType::Request => {
+                        let value = msg.payload_as_value().unwrap_or_default();
+                        channel.send_response(msg.id, &msg.method, &value).await?;
+                    }
+                    Ok(_) => {}
+                    Err(e) if e.is_normal_close() => return Ok(()),
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+        .await;
+    let handle = server.spawn_listen("[::1]:0").await?;
+    let addr = handle.local_addr();
+    let addr = format!("[{}]:{}", addr.ip(), addr.port());
+
+    // 素の connect で従来通り動作する
+    let client = ProtocolClient::new_default()?;
+    client.connect(&addr).await?;
+    let channel = client.open_channel("echo").await?;
+    let resp: Value = timeout(
+        Duration::from_secs(5),
+        channel.request("Echo", &json!({ "msg": "hi" })),
+    )
+    .await??;
+    assert_eq!(resp["msg"], json!("hi"));
+
+    channel.close().await?;
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}

--- a/crates/unison-protocol/tests/test_integ_auth.rs
+++ b/crates/unison-protocol/tests/test_integ_auth.rs
@@ -67,8 +67,11 @@ async fn start_auth_server() -> Result<(ServerHandle, String)> {
     let server = ProtocolServer::with_identity("test-auth-srv", "0.1.0", "test");
     server
         .enable_auth(|credential: Vec<u8>| async move {
-            (credential == GOOD_TOKEN)
-                .then(|| Arc::new(TestUser { name: "alice".into() }) as Principal)
+            (credential == GOOD_TOKEN).then(|| {
+                Arc::new(TestUser {
+                    name: "alice".into(),
+                }) as Principal
+            })
         })
         .await;
     server.register_channel(SECRET_CHANNEL, handle_secret).await;
@@ -97,7 +100,11 @@ async fn test_e2e_auth_valid_credential_passes_gate() -> Result<()> {
     .await??;
 
     assert_eq!(resp["authed"], json!(true), "authed should be true");
-    assert_eq!(resp["whoami"], json!("alice"), "principal name should leak through downcast");
+    assert_eq!(
+        resp["whoami"],
+        json!("alice"),
+        "principal name should leak through downcast"
+    );
 
     channel.close().await?;
     client.disconnect().await?;

--- a/design/README.md
+++ b/design/README.md
@@ -17,6 +17,7 @@
 |------------|------|----------|
 | [architecture.md](architecture.md) | 全体アーキテクチャ設計詳細 | [spec/01](../spec/01-core-concept/SPEC.md) |
 | [packet.md](packet.md) | UnisonPacket実装仕様 | [spec/01](../spec/01-core-concept/SPEC.md) |
+| [connection-auth.md](connection-auth.md) | Connection-level auth primitive（mechanism/policy 分離） | — |
 | [test-strategy.md](test-strategy.md) | テスト戦略（3x3マトリクス） | — |
 
 ## 設計ドキュメントの書き方

--- a/design/connection-auth.md
+++ b/design/connection-auth.md
@@ -1,0 +1,301 @@
+# design/connection-auth.md — Connection-level Auth Primitive 設計
+
+**バージョン**: 0.2 (設計確定 2026-06-27、 実装完了 2026-06-27)
+**最終更新**: 2026-06-27
+**ステータス**: 実装済 (= `network/auth.rs` + `enable_auth` + `connect_with_credential`、 E2E test 4件 green)
+**対応仕様**: （未作成 — 必要なら `spec/05-auth/SPEC.md` を mirror）
+**設計 SSOT**: Context Engine `mem_1CcTT4yxguA1KjGJXXHFor` / 実装 handoff `mem_1CcTTLKuuTYGfATSKdSo8J`
+
+---
+
+## 1. 背景
+
+unison の全エンドポイント間通信（federation worlds channel / 連邦 wire / live streaming）に
+認証を入れたい。ただし「どの層・どの粒度で認証するか」を誤ると、live streaming の小フレーム
+fan-out を殺す。本設計は **認証を connection 確立時に1回行う primitive** として club-unison
+に入れることを確定する。
+
+これ待ちが 3 件ある:
+
+- **hub federation**（chronista-hub ADR-020 §S3）: worlds channel + 連邦 wire の auth。
+  hub は Creo ID JWKS verifier を policy として注入するだけにしたい。
+- **VP wire-unison 移行**（vantage-point doc 27 B-4）: 同じ auth を各 protocol で再発明させない。
+- **live streaming**（position / audio / asset の小フレーム fan-out）: per-message token だと
+  frame が膨らむ → connection-level 必須（datagram は connection auth 以外に手段なし）。
+
+---
+
+## 2. 決定
+
+### 2.1 auth = connection-level の club-unison primitive
+
+- **authN（誰だ）= connection 確立時に1回**: client が credential（opaque bytes、例
+  Creo ID JWT）を post-handshake で1回提示 → club-unison が **verifier callback（app 注入）**
+  に渡す → 結果の **principal を [`ConnectionContext`] に保持**。
+- **authZ（その動詞を許すか）= per-message**: channel handler が `ctx` の principal を引いて
+  scope check。**フレームには 1 byte も足さない**。
+
+### 2.2 mechanism / policy 分離（`CertSource` 哲学の踏襲）
+
+- **mechanism = club-unison**: 「connection 確立直後に credential を1回受け取り、 verifier に
+  渡し、 principal を ctx に立てる」配管。
+- **policy = app（operator）**: verifier を注入。hub なら既存 Creo ID JWKS（client-cert PKI
+  不要、 credential = Creo ID JWT）。
+- これは [`CertSource`]（`network/cert.rs`）の「**library は trust model を選ばない、
+  operator が選ぶ**」と完全同型。auth も同じ思想で設計する。
+
+---
+
+## 3. Mental model
+
+### 3.1 authN は場への attach、 authZ は場の中の動詞
+
+doctrine（場×動詞×規律）で言えば、auth =「誰がこの場に attach して tell/observe/ask できるか」
+= 場への**アクセスの規律**。場に attach する瞬間（= connection 確立）に1回問うものであって、
+場の中で流す各フレームに問うものではない。→ connection-level auth は doctrine の literal。
+
+### 3.2 discovery primitive との対比
+
+auth は `unison.discovery`（`design/datagram-channel.md` 兄弟、`spec/04-discovery`）と
+**同型の reserved-channel パターン**で実装する。差分は handler が `ctx` を使う点のみ。
+
+| | `unison.discovery` | `unison.auth`（本設計） |
+|---|---|---|
+| 有効化 API | `server.enable_discovery(kdl)` | `server.enable_auth(verifier)` |
+| reserved channel 名 | `DISCOVERY_CHANNEL_NAME` | `AUTH_CHANNEL_NAME` |
+| handler | `handle_channel(cache, stream)` | `handle_channel(verifier, ctx, stream)` |
+| ctx の使用 | しない（`move \|_ctx, stream\|`） | **する**（principal を set） |
+| client 側 | `client.open_channel(...)` | `client.connect_with_credential(...)` helper |
+| policy 注入物 | protocol KDL | verifier callback |
+
+---
+
+## 4. なぜ connection-level か（= per-message でない理由）★ load-bearing
+
+live streaming（origin→distribution→client 群 の fan-out、 position/audio/asset の小フレーム
+高頻度）を unison transport の北極星に置くと、粒度の選択は一意に決まる:
+
+- **per-message token は dead-end**: position frame（数バイト）に token を載せると auth が
+  ペイロードより大きい。高頻度で throughput を殺す。
+- **connection-level は per-frame 0 bytes**: TLS/QUIC handshake + 1 回の auth 交換で済み、
+  以降の全 frame は auth 無料。「最初の数 turn だけ払い以降 0」。
+- **datagram は connection-level 以外に選択肢が無い**: datagram channel（position 等
+  latest-wins）は stream を持たず per-datagram auth を打てない → QUIC connection が認証済み
+  なら datagram は auth を無料継承。
+- **fan-out スケール**: 各 hop = 1 connection を setup 時に 1 回認証。distribution server は
+  downstream client を接続時 1 回認証 → fan-out frame は auth 0。100k client でもコストは
+  「接続を受ける」分のみ、 per-frame に乗らない。
+
+---
+
+## 5. 実装設計
+
+`unison.discovery` の配線を 1:1 で踏襲する。新規モジュール `network/auth.rs` を起こし、
+`context.rs` / `server.rs` / `client.rs` に最小の足し込みを行う。
+
+### 5.1 `ConnectionContext` に principal を追加（`network/context.rs`）
+
+現状 `ConnectionContext` は `connection_id` / `identity` / `channels` のみで client identity を
+持たない。ここに principal を足す:
+
+```rust
+pub struct ConnectionContext {
+    pub connection_id: Uuid,
+    identity: Arc<RwLock<Option<ServerIdentity>>>,
+    channels: Arc<RwLock<HashMap<String, ChannelHandle>>>,
+    /// 認証済み client principal（未認証なら None）。
+    /// club-unison は中身を知らない（opaque）。app が downcast する。
+    principal: Arc<RwLock<Option<Principal>>>,
+}
+
+/// opaque な principal。club-unison は型を一切解釈しない。
+pub type Principal = Arc<dyn std::any::Any + Send + Sync>;
+
+impl ConnectionContext {
+    pub async fn set_principal(&self, p: Principal) { /* write guard */ }
+    pub async fn principal(&self) -> Option<Principal> { /* read guard clone */ }
+}
+```
+
+**型選択 — `Arc<dyn Any + Send + Sync>` を採用**（§6 で論拠）。`ConnectionContext<P>` と
+ジェネリック化すると `register_channel` の handler 型 `Fn(Arc<ConnectionContext>, ...)` 経由で
+`P` が dispatch 全体に伝播する。非ジェネリックな opaque 型に保つことで変更を `context.rs` に
+局所化でき、「club-unison は principal の中身を知らない」も literal に満たせる。
+
+### 5.2 `enable_auth(verifier)`（`network/server.rs`）
+
+`enable_discovery` と同型。reserved channel `AUTH_CHANNEL_NAME` を登録する。verifier は
+**async**（JWKS の network fetch を伴う実 use case に合わせ確定）。credential は所有権ごと
+渡す（`async move` ブロックへ move できる）:
+
+```rust
+/// connection-level 認証を有効化する。client が接続直後に `unison.auth` を open →
+/// credential を 1 request 送る → verifier (= app 注入) で検証 → 返った principal を
+/// その connection の ctx に set する。
+///
+/// verifier = policy（app 注入）。club-unison は credential の中身を知らない。
+pub async fn enable_auth<V, Fut>(&self, verifier: V)
+where
+    V: Fn(Vec<u8>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Option<Principal>> + Send + 'static,
+{
+    // closure を box 化して非ジェネリックな Verifier に詰める
+    let verifier: super::auth::Verifier =
+        Arc::new(move |cred| Box::pin(verifier(cred)) as _);
+    self.register_channel(super::auth::AUTH_CHANNEL_NAME, move |ctx, stream| {
+        let verifier = Arc::clone(&verifier);
+        async move { super::auth::handle_channel(verifier, ctx, stream).await }
+    })
+    .await;
+}
+```
+
+### 5.3 `network/auth.rs`（新規モジュール）
+
+`discovery.rs` を template に:
+
+```rust
+/// `unison.auth` channel name（schemas/auth.kdl 側と一致）
+pub const AUTH_CHANNEL_NAME: &str = "unison.auth";
+/// credential 提示メソッド
+pub const AUTHENTICATE_METHOD: &str = "Authenticate";
+
+/// app 注入の認証 verifier（= policy）。credential を所有権ごと受け取り、async で検証。
+pub type Verifier =
+    Arc<dyn Fn(Vec<u8>) -> Pin<Box<dyn Future<Output = Option<Principal>> + Send>> + Send + Sync>;
+
+/// `unison.auth` channel handler。credential を 1 request 受け取り、verifier に
+/// 渡し、principal を ctx に set し、ok/deny を返す。
+pub async fn handle_channel(
+    verifier: Verifier,
+    ctx: Arc<ConnectionContext>,
+    stream: UnisonStream,
+) -> Result<(), NetworkError> {
+    // 1. request 受信（AuthenticateRequest { credential: Vec<u8> }）
+    // 2. verifier(credential).await → Option<Principal>
+    // 3. Some(p) → ctx.set_principal(p) → AuthResult { ok: true }
+    //    None    → AuthResult { ok: false }（principal は None のまま）
+    //    malformed payload → ok: false（verifier に渡さない）
+}
+```
+
+### 5.4 client が credential を提示（`network/client.rs`）
+
+接続直後に `unison.auth` を open して送る helper を足す:
+
+```rust
+/// connect 後に credential を 1 回提示する。内部で unison.auth を open し
+/// Authenticate request を送り、ok/deny を待つ。
+pub async fn connect_with_credential(&self, url: &str, credential: &[u8])
+    -> Result<(), NetworkError>
+{
+    self.connect(url).await?;
+    let chan = self.open_channel(super::auth::AUTH_CHANNEL_NAME).await?;
+    // Authenticate request を送り、deny なら Err
+}
+```
+
+### 5.5 authZ は app 側（mechanism/policy 分離）
+
+各 channel handler が `ctx.principal()` を引いて gate する。club-unison は principal を
+**提供するだけ**で、何を要求するか（scope / role）は app が決める:
+
+```rust
+server.register_channel("worlds", |ctx, stream| async move {
+    let principal = ctx.principal().await
+        .and_then(|p| p.downcast_ref::<MyPrincipal>().cloned()); // app の型
+    let Some(principal) = principal else {
+        return Err(/* unauthenticated */);
+    };
+    // principal.scopes で per-message gate ...
+});
+```
+
+### 5.6 ctx 共有の保証（実装前 検証済 ✅）
+
+本設計は「`unison.auth` handler が立てた principal を worlds/wire/datagram handler が読める」
+ことに依存する。これは **同一 connection の全 channel handler が同じ `Arc<ConnectionContext>`
+を共有する**ことで成立する。`network/dispatch.rs` が connection ごとに ctx を 1 つ作り、
+各 channel handler 起動時に `Arc::clone(&ctx)` を渡している（dispatch.rs の
+`let ctx = Arc::clone(&ctx);` → `handler(ctx, stream).await`）ことを確認済み。
+
+### 5.7 `schemas/auth.kdl`
+
+`schemas/discovery.kdl` と同型で reserved channel を定義する:
+
+```kdl
+channel "unison.auth" from="client" lifetime="persistent" {
+    request "Authenticate" {
+        // credential は opaque bytes。KDL schema に native bytes 型が無く、 JSON codec
+        // 上は byte 配列 ([u8]) として運ばれるため type="json"（任意 JSON 可）とする。
+        field "credential" type="json" required=#true
+        returns "AuthResult" {
+            field "ok" type="bool" required=#true
+        }
+    }
+}
+```
+
+---
+
+## 6. 型・API の確定事項（実装済）
+
+| 論点 | 確定 | 論拠 |
+|------|------|------|
+| principal の型 | `Arc<dyn Any + Send + Sync>` | 非ジェネリック維持で変更を context.rs に局所化。完全 opaque。 |
+| verifier の sync/async | **async**（`Fn(Vec<u8>) -> Future<Option<Principal>>`） | hub の Creo ID JWKS が cache miss 時に network fetch する実態に合う。最初から正しい形で API 破壊を回避。 |
+| credential の wire 型 | `Vec<u8>`（KDL は `json`） | club-unison は中身を知らない。JWT も binary token も載る。接続時1回のみで per-frame でない。 |
+| 未認証時の挙動 | principal = None のまま接続維持 | gate は app 責務。connection は切らず handler が拒否。 |
+
+> 2026-06-27 の plan phase で user 承認のうえ確定・実装。
+
+---
+
+## 7. Acceptance criteria
+
+- credential 無し / 不正で接続 → `ctx.principal()` = None → app handler が gated method を拒否。✅
+- 正当 credential → principal set → per-message scope check 通過、 **per-frame に auth byte 0**。✅
+- verifier は app 注入（club-unison は Creo ID を知らない）。✅
+- `unison.discovery` と同様、`enable_auth` を呼ばない server は従来通り（auth 無効・非破壊）。✅
+
+E2E 検証: `crates/unison-protocol/tests/test_integ_auth.rs`（4 ケース、全 green）。
+
+### 既知の制約 / 将来拡張
+- **datagram の principal 継承（transport のみ）**: 認証済み QUIC connection 上を datagram は
+  そのまま流れる（= per-datagram auth 不要）。ただし stream channel handler が `Fn(Arc<ctx>,
+  stream)` で ctx を受け取るのに対し、 **datagram channel handler は `Fn(DatagramChannel)` で
+  ctx を受け取らない**（`network/server.rs::register_channel_datagram`）。そのため datagram
+  handler 内から `ctx.principal()` を引いた app-level gate は現状できない。datagram に
+  principal-based gate が必要になったら、 datagram handler に ctx を渡す拡張を別途行う
+  （本 primitive の範囲外、 forward-compatible）。
+
+---
+
+## 8. E2E（別レイヤー、 当面不要）
+
+distribution が **trusted infra** なら hop-by-hop connection auth で十分。distribution が
+**untrusted（公開リレー）** で「origin 署名を client が検証」したい場合のみ、**content 署名**
+（stream/chunk 単位、 per-frame でない）を transport auth と直交に足す。Chronista の
+trusted-peer-mesh 前提では当面不要。
+
+---
+
+## 9. 短期 fallback（club-unison 実装前に hub が unblock 要時）
+
+hub-protocol 内の **channel-open auth**（worlds channel の最初の message を Authenticate に）で
+代替可。attach-time なので本 primitive と **forward-compatible**（後で剥がす痛みなし）。
+**per-message token には降りない**。
+
+---
+
+## 10. 関連
+
+- 設計 SSOT: Context Engine `mem_1CcTT4yxguA1KjGJXXHFor`
+- 実装 handoff: Context Engine `mem_1CcTTLKuuTYGfATSKdSo8J`
+- mechanism/policy 先例: [`CertSource`]（`network/cert.rs`）
+- reserved-channel 先例: `unison.discovery`（`network/discovery.rs`、`spec/04-discovery`）
+- ctx 共有: `network/dispatch.rs`
+- 依存: chronista-hub federation ADR-020 / VP wire-unison 移行（B-4）
+
+[`ConnectionContext`]: ../crates/unison-protocol/src/network/context.rs
+[`CertSource`]: ../crates/unison-protocol/src/network/cert.rs

--- a/schemas/auth.kdl
+++ b/schemas/auth.kdl
@@ -1,0 +1,44 @@
+// Unison Auth — connection-level authentication channel schema.
+//
+// 設計: design/connection-auth.md
+// 起源: chronista-hub federation (ADR-020) の S3 discovery auth を詰める過程で確定。
+//       federation worlds channel / 連邦 wire / live streaming の認証を connection
+//       確立時に1回行う primitive として club-unison に入れる。
+//
+// 目的:
+//   client が接続直後に credential を1回提示し、 server 側 verifier (= app 注入の
+//   policy) が検証して principal を connection に立てる (= authN)。以降の authZ
+//   (= per-message scope check) は app 側が ConnectionContext::principal を引いて
+//   行い、 フレームには auth byte を 1 つも足さない (= per-frame 0 bytes)。
+//
+// mechanism / policy 分離:
+//   このスキーマは mechanism (= credential を運ぶ配管) のみを定義する。credential /
+//   principal の中身 (Creo ID JWT / API キー / 独自トークン) は verifier (= policy)
+//   が解釈し、 library は一切関知しない。これにより club-unison は特定の認証
+//   エコシステムに依存しない (= cert.rs CertSource が trust model を選ばないのと同型)。
+//
+// スコープ外 (= 別レイヤー / 後続):
+//   - verifier の実装 (= Creo ID JWKS 等は app 側、 policy)
+//   - E2E content 署名 (= distribution が untrusted な場合のみ、 transport auth と直交)
+//   - re-authentication / credential rotation (= 必要兆候が出たら別 request method で)
+
+protocol "unison-auth" version="0.1.0" {
+    namespace "club.chronista.unison.auth"
+
+    channel "unison.auth" from="client" lifetime="persistent" {
+
+        // Client → Server: 接続直後に credential を1回提示して認証する。
+        request "Authenticate" {
+            // opaque な credential。 library は中身を解釈せず verifier にそのまま渡す。
+            // wire 上は JSON codec で byte 配列 (= [u8]) として運ばれる。接続時1回のみで
+            // per-frame ではないので array 表現のコストは問題にならない。
+            field "credential" type="json" required=#true
+
+            returns "AuthResult" {
+                // verifier が principal を返した (= 認証成功) なら true。
+                // false の場合 principal は立たず、 app handler が gated method を拒否する。
+                field "ok" type="bool" required=#true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要

全エンドポイント間通信（federation worlds channel / 連邦 wire / live streaming）の認証を **connection 確立時に1回**行う primitive を追加します。authN を connection に、authZ を per-message（`ctx.principal()` を引く app 側 gate）に分離し、**per-frame に auth byte 0**。live streaming の小フレーム fan-out / datagram を auth コストで殺さないための設計です。

- 設計 SSOT: `design/connection-auth.md`
- これ待ちが3件: hub federation（ADR-020 §S3）/ VP wire-unison 移行（B-4）/ live streaming

## 設計: mechanism / policy 分離（`CertSource` 哲学の踏襲）

`unison.discovery` の reserved-channel パターンを 1:1 踏襲しています。

- **mechanism = club-unison**: credential を接続直後に1回受け取り、verifier に渡し、principal を ctx に立てる配管。
- **policy = app（operator）**: verifier を注入。credential / principal の中身（Creo ID JWT / API キー / 独自トークン）は app が解釈し、**library は一切関知しない**。

### OSS として ecosystem-neutral

`unison-protocol` crate に `jsonwebtoken` / `auth0` / `jwks` 等の依存・型は**ゼロ**（Creo ID 等への言及は「依存しない」ことを説明する doc コメントのみ）。opaque な三層 —— credential = `Vec<u8>` / verifier = closure / principal = `Arc<dyn Any>` —— が、特定の認証エコシステムへの lock-in を型レベルで防ぎます。`enable_auth` は **opt-in**（呼ばなければ従来通り・非破壊）。

## API

```rust
// server (policy = app 注入の async verifier)
server.enable_auth(|credential: Vec<u8>| async move {
    verify_creo_id(&credential).await
        .map(|user| std::sync::Arc::new(user) as Principal)
}).await;

// client
client.connect_with_credential(&addr, credential).await?;

// authZ は app 側 (= per-message gate、 per-frame 0 bytes)
let principal = ctx.principal().await
    .and_then(|p| p.downcast_ref::<MyUser>().cloned());
```

## 変更点

| 種別 | 内容 |
|------|------|
| 新規 | `network/auth.rs`（`unison.auth` handler、async `Verifier`、`AuthenticateRequest`/`AuthResult`） |
| 新規 | `schemas/auth.kdl` / `design/connection-auth.md` / `tests/test_integ_auth.rs` |
| 変更 | `ConnectionContext`: `Principal` + `set_principal`/`principal()` |
| 変更 | `ProtocolServer::enable_auth(verifier)`（opt-in、`enable_discovery` と同型） |
| 変更 | `ProtocolClient::connect_with_credential(url, credential)` |

## 既知の制約 / 将来拡張

- **datagram の principal 継承は transport レベルのみ**: 認証済み QUIC connection 上を datagram はそのまま流れる（per-datagram auth 不要）が、`register_channel_datagram` の handler は `Fn(DatagramChannel)` で ctx を受け取らないため、datagram handler 内からの `ctx.principal()` gate は現状不可。必要になれば handler へ ctx を渡す拡張を別途（forward-compatible）。

## 検証

- lib unit: 164 passed（新規9件含む）
- E2E: 4 passed（`cargo test -p club-unison --test test_integ_auth -- --ignored`）—— 正当 credential 通過 / 不正拒否 / 未認証 gate / `enable_auth` 未呼出の非破壊
- `cargo clippy --lib --workspace -- -D warnings`: 0 warnings
- `cargo test --workspace`: 0 failed

設計 SSOT: `mem_1CcTT4yxguA1KjGJXXHFor` / handoff: `mem_1CcTTLKuuTYGfATSKdSo8J`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8F2swZjY2DVf4S3dXsbWt
