### PR TITLE
build(swift): Package.swift を repo root へ（SPM url+version 配布を有効化）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,12 +229,11 @@ jobs:
   # NWProtocolQUIC / swift-protobuf を使う SPM package。生成 wire コードは
   # コミット済みなので protoc 不要。LiveE2ETests は UNISON_LIVE 環境変数で gate
   # され (mock server 必須)、ここでは未設定なので skip される。
+  # Package.swift は repo root (SPM の version 指定 remote 依存が root manifest を
+  # 要求するため)、source 実体は clients/swift/ 配下。よって build/test は root で実行。
   swift:
     name: Swift Client
     runs-on: macos-latest
-    defaults:
-      run:
-        working-directory: clients/swift
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 /target/
 Cargo.lock
 
+# Swift Package Manager (root Package.swift; sources live under clients/swift/)
+/.build/
+/.swiftpm/
+/Package.resolved
+
 # IDE
 .vscode/
 .idea/

--- a/Package.swift
+++ b/Package.swift
@@ -2,8 +2,18 @@
 import PackageDescription
 
 // Unison protocol — Swift client SDK (polyglot client base、 server stays Rust)。
-// ruby / typescript の swift sibling。 transport = Apple Network.framework の
-// NWProtocolQUIC (生 QUIC: streams + datagrams, ALPN "unison")、 wire = swift-protobuf。
+//
+// この Package.swift は **monorepo root** に置く。SPM は version 指定リモート依存
+// (`.package(url:, from:)`) に「repo root の manifest」を要求し、 subdirectory の
+// manifest を解決できないため。実体 source は `clients/swift/` 配下に集約したまま、
+// target の `path:` で参照する (= monorepo にコードを集約しつつ SPM 配布も成立)。
+//
+// 版数は monorepo の git tag (`vX.Y.Z` = Rust workspace 版) に連動する (= 意図的。
+// club-unison 全体で揃った版数で配布、 Swift client を独立 versioning しない)。
+// consumer: `.package(url: "https://github.com/chronista-club/club-unison.git", from: "1.4.0")`
+//
+// transport = Apple Network.framework の NWProtocolQUIC (生 QUIC: streams +
+// datagrams, ALPN "unison")、 wire = swift-protobuf。
 let package = Package(
     name: "UnisonClient",
     platforms: [
@@ -23,11 +33,14 @@ let package = Package(
             name: "UnisonClient",
             dependencies: [
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
-            ]
+            ],
+            // source 実体は monorepo の clients/swift/ 配下 (root manifest から path 参照)。
+            path: "clients/swift/Sources/UnisonClient"
         ),
         .testTarget(
             name: "UnisonClientTests",
             dependencies: ["UnisonClient"],
+            path: "clients/swift/Tests/UnisonClientTests",
             // Rust `tests/fixtures/wire/` の golden byte vector を取り込み、
             // Swift encoder の出力が Rust と byte 一致することを検証する。
             resources: [.copy("Fixtures")]

--- a/README.md
+++ b/README.md
@@ -233,13 +233,20 @@ The server stays Rust; clients are first-class siblings under [`clients/`](https
 |--------|-----------|--------------|
 | [`clients/typescript`](https://github.com/chronista-club/club-unison/tree/main/clients/typescript) | WebTransport (HTTP/3) | npm `@chronista-club/unison-client` |
 | [`clients/ruby`](https://github.com/chronista-club/club-unison/tree/main/clients/ruby) | raw QUIC (FFI → Rust) | RubyGems `unison-client` |
-| [`clients/swift`](https://github.com/chronista-club/club-unison/tree/main/clients/swift) | raw QUIC (Apple `NWProtocolQUIC`, ALPN `"unison"`) | SPM (monorepo path / git) — see note |
+| [`clients/swift`](https://github.com/chronista-club/club-unison/tree/main/clients/swift) | raw QUIC (Apple `NWProtocolQUIC`, ALPN `"unison"`) | SPM (`Package.swift` at repo root) — see note |
 
-> **Swift package consumption**: `clients/swift` の `Package.swift` は repo の
-> サブディレクトリにあり、SPM の version 指定 remote 依存 (`.package(url:from:)`)
-> は repo root の `Package.swift` を前提とするため使えない。consumer (例: VP) は
-> **path 依存** (`.package(path: "../club-unison/clients/swift")`、monorepo 隣接)
-> で参照する。将来 versioned 配布が要るなら別 repo 切り出しを検討。
+> **Swift package consumption**: `Package.swift` は **repo root** にあり (SPM の
+> version 指定 remote 依存 `.package(url:from:)` は root manifest を要求するため)。
+> source 実体は `clients/swift/` 配下で、root manifest が `path:` で参照する
+> (= monorepo にコード集約しつつ SPM 配布も成立)。版数は monorepo の git tag
+> (`vX.Y.Z` = Rust workspace 版) に連動する (Swift client は独立 versioning しない)。
+>
+> ```swift
+> .package(url: "https://github.com/chronista-club/club-unison.git", from: "1.4.0")
+> // target: .product(name: "UnisonClient", package: "club-unison")
+> ```
+>
+> monorepo 隣接の開発なら path 依存も可: `.package(path: "../club-unison")`。
 
 ---
 

--- a/clients/swift/README.md
+++ b/clients/swift/README.md
@@ -75,11 +75,15 @@ struct Ping: UnisonRequest {
 
 `LiveE2ETests` は CI 非対象(環境変数で gate)。`unison mock`(quinn)相手に実 QUIC round-trip を確認する:
 
+`Package.swift` は **repo root** にあり (SPM の version 指定 remote 依存が root manifest を
+要求するため)。source 実体はこの `clients/swift/` 配下で、root manifest が `path:` で参照する。
+よって `swift build` / `swift test` は **repo root** で実行する。
+
 ```bash
 # 1) Rust 側で mock server を起動
 target/debug/unison mock --schema schemas/ping_pong.kdl --addr '[::1]:7878'
-# 2) Swift 側で live test
-cd clients/swift && UNISON_LIVE=1 swift test --filter LiveE2E
+# 2) Swift 側で live test (repo root で)
+UNISON_LIVE=1 swift test --filter LiveE2E
 ```
 
 connect(ALPN "unison")→ openChannel → request → response decode が **Apple NWProtocolQUIC ↔ Rust quinn** で interop することの最終証明。
@@ -87,7 +91,7 @@ connect(ALPN "unison")→ openChannel → request → response decode が **Appl
 ## 開発
 
 ```bash
-cd clients/swift
+# repo root で (Package.swift は root、source は clients/swift/ 配下)
 swift build
 swift test          # scaffold smoke test (型 + 純粋ロジック)
 ```


### PR DESCRIPTION
## 概要

Swift client を `.package(url: "...club-unison.git", from: "1.4.0")` で消費できるようにする。SPM は version 指定 remote 依存に **repo root の `Package.swift`** を要求し、subdirectory manifest を解決できないため。

ミラーrepo は作らず、**コードは monorepo に集約したまま** root manifest が `path:` で `clients/swift/` を参照する形にした。版数は monorepo の git tag（`vX.Y.Z` = Rust workspace 版）に連動（Swift client は独立 versioning しない）。

## 変更
- `Package.swift`（repo root、新規）: target の `path:` で `clients/swift/Sources`・`Tests` を参照
- `clients/swift/Package.swift` 削除（manifest 二重化を避ける）
- CI Swift job: `working-directory` を外し root で `swift build`/`swift test`
- `.gitignore`: root の `/.build/` `/.swiftpm/` `/Package.resolved`
- README / clients/swift/README: 消費・開発手順を root build に更新

## 検証
- repo root で `swift build` / `swift test`（22 tests、auth + fixture byte-compat 含む）PASS
- Rust コードは無変更（crates.io 1.4.0 の中身と矛盾なし）

## ⚠️ マージ後の tag 対応（要判断）
`v1.4.0` tag は現状 root Package.swift を含まない commit を指すため、SPM `from:"1.4.0"` がそのままでは解決不可。本PRは Rust 無変更なので、マージ後に **`v1.4.0` を新 commit へ移動**（fresh tag・Rust 中身同一なので安全）するか、**`v1.4.1` を新規**で切る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8F2swZjY2DVf4S3dXsbWt