### PR TITLE
feat(network): server-initiated reliable stream（ServerToClient を起こす）= 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-28 — server-initiated reliable stream (`ServerToClient` を起こす)
+
+> server 起点で connected client へ **reliable・同順** な stream を開く primitive を追加。
+> 既に型・KDL (`from="server"`) に宣言されながら runtime で無視されていた
+> `ChannelDirection::ServerToClient` を本物にする。reliable は新しい配送 mode ではなく、
+> **client 側の受信 handler を server 側と対称化**（どちらも raw `UnisonStream` を直読）して
+> 構造的に得る — recv ループ／中継 mpsc を挟まないので、遅い consumer には QUIC flow-control
+> backpressure が掛かり、取りこぼしも OOM も起きない。chronista-hub federation relay
+> (ADR-020 §S4) の substrate floor。SemVer minor (= additive、opt-in、既存 API 不変)。
+>
+> 設計: `design/server-initiated-stream.md`（SSOT）
+
+### Added
+
+- **server-initiated reliable stream** (`network::context` / `network::client` / `network::dispatch`):
+  server が connected client へ取りこぼし無く push できる stream primitive。
+  - `ConnectionContext::open_server_stream(channel) -> UnisonStream`: server 起点で双方向
+    stream を開き、先頭に channel 宣言 frame (= `__identity` と同形) を 1 本書く。以降の
+    payload は返した raw `UnisonStream` で授受する。stream は persistent (`finish()` しない)。
+    既存の `UnisonConn::open_bi()` を再利用し、新しい transport 動詞は増やさない。
+  - `ProtocolClient::register_server_channel(channel, handler)`: client が `from="server"`
+    channel の handler を登録。handler は raw `UnisonStream` を受け取り**直読**する
+    (= server 側 `register_channel` handler と対称)。`connect` 前に登録する。
+  - `ConnectionContext::set_conn`: `handle_connection` が server 側でのみ接続を ctx に渡す
+    (1 行注入)。client 側 ctx は conn 未 set のままで、`open_server_stream` は誤用 error。
+
+### Changed
+
+- `client_accept_bi_loop`: server 発信 stream を先頭 frame の method で振り分けるよう一般化。
+  `__identity` は従来どおり専用 oneshot、それ以外は server-channel registry を引いて handler へ
+  `UnisonStream` を渡す。**未登録 channel は従来どおり drop + warn**（後方互換 = 無回帰）。
+
+### Notes
+
+- **完全性 (no-drop) の根拠**: dedicated QUIC stream を直読すると、handler が読まない間に
+  受信 window が埋まり送信側が QUIC flow-control で throttle される。完全性は queue
+  (bounded→drop / unbounded→OOM) でなく **end-to-end backpressure** が生む。
+- **scope 外 (剃刀)**: `get_connection_by_principal` 等の lookup table / relay 専用 API は
+  substrate に置かない (利用側 = hub が `wld_id→ctx` map を持つ)。aggregate (多重相関) と
+  既存 `UnisonChannel` の global reliable 化は consumer が出るまで保留。
+- **制約**: client 受信経路は raw QUIC 専用 (`client_accept_bi_loop` が `quinn::Connection`)
+  のため、WebTransport client は server-initiated channel を受けられない (native client は可)。
+  `build_identity()` の `from="server"` honor は direction source 整備が前提のため本リリースでは
+  未対応 (schema↔runtime 齟齬は残置、二次的)。
+
 ## [1.4.0] - 2026-06-27 — connection-level auth primitive (mechanism/policy 分離)
 
 > 全エンドポイント間通信 (federation worlds channel / 連邦 wire / live streaming) の認証を

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/crates/unison-protocol/src/network/client.rs
+++ b/crates/unison-protocol/src/network/client.rs
@@ -145,6 +145,22 @@ impl ProtocolClient {
         self.context.identity().await
     }
 
+    /// server-initiated channel (= `from="server"`) の handler を登録する。
+    ///
+    /// server が [`ConnectionContext::open_server_stream`](super::context::ConnectionContext::open_server_stream)
+    /// で開いた server→client の reliable push stream を、宣言 frame の method (= `channel`) で
+    /// この handler に routing する。handler は渡された raw [`UnisonStream`] を **直読** して
+    /// payload を取りこぼし無く受ける（recv ループ／中継 mpsc を挟まない = QUIC backpressure）。
+    ///
+    /// `connect` 前に登録しておくこと。同 `channel` で再登録すると古い handler を replace する。
+    pub async fn register_server_channel<F, Fut>(&self, channel: &str, handler: F)
+    where
+        F: Fn(UnisonStream) -> Fut + Send + Sync + 'static,
+        Fut: futures_util::Future<Output = Result<(), NetworkError>> + Send + 'static,
+    {
+        self.transport.register_server_channel(channel, handler).await;
+    }
+
     /// チャネルを開く（UnisonChannel を返す）
     ///
     /// `__channel:{name}` メソッドで新しいQUICストリームを開き、 サーバーが返す

--- a/crates/unison-protocol/src/network/client.rs
+++ b/crates/unison-protocol/src/network/client.rs
@@ -158,7 +158,9 @@ impl ProtocolClient {
         F: Fn(UnisonStream) -> Fut + Send + Sync + 'static,
         Fut: futures_util::Future<Output = Result<(), NetworkError>> + Send + 'static,
     {
-        self.transport.register_server_channel(channel, handler).await;
+        self.transport
+            .register_server_channel(channel, handler)
+            .await;
     }
 
     /// チャネルを開く（UnisonChannel を返す）

--- a/crates/unison-protocol/src/network/context.rs
+++ b/crates/unison-protocol/src/network/context.rs
@@ -9,7 +9,11 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
+use super::conn::UnisonConn;
+use super::frame::{FRAME_TYPE_PROTOCOL, write_typed_frame};
 use super::identity::{ChannelDirection, ServerIdentity};
+use super::stream::UnisonStream;
+use super::{MessageType, NetworkError, ProtocolMessage};
 
 /// 認証済み client の principal。
 ///
@@ -24,7 +28,9 @@ use super::identity::{ChannelDirection, ServerIdentity};
 pub type Principal = Arc<dyn Any + Send + Sync>;
 
 /// 接続ごとの状態を管理する構造体
-#[derive(Debug)]
+///
+/// `Debug` は手書き（derive 不可）。`conn` の `dyn UnisonConn` が `Debug` 非実装の
+/// ためで、出力では conn を「設定有無」だけに畳む。
 pub struct ConnectionContext {
     /// 接続の一意識別子
     pub connection_id: Uuid,
@@ -38,6 +44,13 @@ pub struct ConnectionContext {
     /// 立て、 worlds/wire/datagram 等 **同一 connection の全 channel handler** が
     /// [`principal`](Self::principal) で読んで authZ gate に使う。
     principal: Arc<RwLock<Option<Principal>>>,
+    /// server 起点で stream を開くための connection（server 側のみ set される）。
+    ///
+    /// [`handle_connection`](super::dispatch) が接続確立直後に
+    /// [`set_conn`](Self::set_conn) で立てる。client 側 ctx は **None のまま**で、
+    /// [`open_server_stream`](Self::open_server_stream) を呼ぶと誤用として error になる
+    /// （server→client の reliable push は server 側からしか開けない）。
+    conn: Arc<RwLock<Option<Arc<dyn UnisonConn>>>>,
 }
 
 /// チャネルのメタデータ
@@ -56,6 +69,7 @@ impl ConnectionContext {
             identity: Arc::new(RwLock::new(None)),
             channels: Arc::new(RwLock::new(HashMap::new())),
             principal: Arc::new(RwLock::new(None)),
+            conn: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -82,6 +96,58 @@ impl ConnectionContext {
     /// のように自分の型へ downcast して authZ gate に使う。
     pub async fn principal(&self) -> Option<Principal> {
         self.principal.read().await.clone()
+    }
+
+    /// server-initiated stream 用の connection を設定する。
+    ///
+    /// [`handle_connection`](super::dispatch) が接続確立直後に **server 側でのみ** 呼ぶ。
+    /// これにより handler が [`open_server_stream`](Self::open_server_stream) で
+    /// server→client の reliable push stream を開けるようになる。
+    pub async fn set_conn(&self, conn: Arc<dyn UnisonConn>) {
+        let mut guard = self.conn.write().await;
+        *guard = Some(conn);
+    }
+
+    /// server 起点で reliable な双方向 stream を開く（`ServerToClient`）。
+    ///
+    /// 先頭に channel 宣言 frame（method = `channel`、`__identity` と同形）を 1 本書き、
+    /// 以降の payload は返した [`UnisonStream`] を **直読** して reliable に授受する
+    /// （recv ループ／中継 mpsc を挟まないので、遅い consumer には QUIC flow-control
+    /// backpressure が掛かり、取りこぼしも OOM も起きない）。stream は persistent なので
+    /// `finish()` はしない。
+    ///
+    /// client 側 ctx（conn 未 set）で呼ぶと誤用として [`NetworkError::Connection`] を返す。
+    ///
+    /// 利用側（例: relay hub）は `wld_id → ctx` の対応を application で保持し、対象 ctx の
+    /// 本メソッドを呼ぶ（substrate に connection lookup table は置かない）。
+    pub async fn open_server_stream(&self, channel: &str) -> Result<UnisonStream, NetworkError> {
+        let conn = self.conn.read().await.clone().ok_or_else(|| {
+            NetworkError::Connection(
+                "open_server_stream requires a server-side connection (client-side ctx?)".to_string(),
+            )
+        })?;
+
+        let (mut send, recv) = conn.open_bi().await?;
+
+        // channel 宣言 frame（__identity と同形）。client はこの method で handler を解決する。
+        let decl = ProtocolMessage::new_with_json(
+            0,
+            channel.to_string(),
+            MessageType::Event,
+            serde_json::json!({}),
+        )?;
+        let frame = decl.into_frame()?;
+        write_typed_frame(&mut send, FRAME_TYPE_PROTOCOL, &frame.to_bytes())
+            .await
+            .map_err(|e| NetworkError::Quic(format!("Failed to write channel declaration: {e}")))?;
+
+        Ok(UnisonStream::from_streams(
+            0,
+            channel.to_string(),
+            conn,
+            send,
+            recv,
+        ))
     }
 
     /// チャネルを登録
@@ -112,6 +178,18 @@ impl ConnectionContext {
 impl Default for ConnectionContext {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl std::fmt::Debug for ConnectionContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // conn (dyn UnisonConn) は Debug 非実装なので「設定有無」だけ示す。
+        // identity / channels / principal は lock を取らずに型のみ表す（Debug が
+        // 競合中の lock を blocking で取らないようにする）。
+        f.debug_struct("ConnectionContext")
+            .field("connection_id", &self.connection_id)
+            .field("has_conn", &self.conn.try_read().map(|g| g.is_some()).ok())
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/unison-protocol/src/network/context.rs
+++ b/crates/unison-protocol/src/network/context.rs
@@ -123,7 +123,8 @@ impl ConnectionContext {
     pub async fn open_server_stream(&self, channel: &str) -> Result<UnisonStream, NetworkError> {
         let conn = self.conn.read().await.clone().ok_or_else(|| {
             NetworkError::Connection(
-                "open_server_stream requires a server-side connection (client-side ctx?)".to_string(),
+                "open_server_stream requires a server-side connection (client-side ctx?)"
+                    .to_string(),
             )
         })?;
 

--- a/crates/unison-protocol/src/network/dispatch.rs
+++ b/crates/unison-protocol/src/network/dispatch.rs
@@ -5,33 +5,58 @@
 //! もここに置く。
 
 use anyhow::Result;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
-use tokio::sync::{Mutex, oneshot};
+use tokio::sync::{Mutex, RwLock, oneshot};
 use tracing::{debug, error, info, warn};
 
 use super::conn::UnisonConn;
 use super::frame::{FRAME_TYPE_PROTOCOL, read_typed_frame, write_channel_ack, write_typed_frame};
 use super::stream::UnisonStream;
-use super::{ProtocolFrame, ProtocolMessage, context::ConnectionContext, server::ProtocolServer};
+use super::{
+    NetworkError, ProtocolFrame, ProtocolMessage, context::ConnectionContext,
+    server::ProtocolServer,
+};
+
+/// client 側 server-initiated channel handler。
+///
+/// server 側の [`ChannelHandler`](super::server::ChannelHandler) と対称だが、client 側は
+/// ctx を持たず raw [`UnisonStream`] のみを受け取る。handler はこの stream を**直読**して
+/// reliable に payload を受ける（recv ループ／中継 mpsc を挟まない = 取りこぼし無し）。
+pub type ClientServerChannelHandler = Arc<
+    dyn Fn(UnisonStream) -> Pin<Box<dyn Future<Output = Result<(), NetworkError>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// channel 名 → handler の registry（client 側、[`register_server_channel`] で登録）。
+///
+/// [`register_server_channel`]: super::client::ProtocolClient::register_server_channel
+pub type ClientServerChannelRegistry = Arc<RwLock<HashMap<String, ClientServerChannelHandler>>>;
 
 /// クライアント側: サーバー発信の双方向ストリームを受け付けるループ
 ///
-/// サーバーが `connection.open_bi()` で開いたストリーム（Identity 送信等）を
-/// `accept_bi()` で受信し、ProtocolMessage に変換する。
-/// `__identity` メッセージは専用の oneshot チャネルに送る。
-///
-/// Unified Channel 設計では server→client 通信は client が開いた channel 上で
-/// 行うため、 server-initiated bi stream の非 identity frame は想定外。 旧実装は
-/// これを無制限 mpsc に積んでいたが drain されず (= dead path + 悪意ある server に
-/// よる OOM ベクタ) だったので、 warn して drop する。
+/// サーバーが `connection.open_bi()` で開いたストリームを `accept_bi()` で受信し、
+/// **先頭 frame の method** で振り分ける:
+/// - `__identity` → Identity 専用の oneshot チャネルへ（従来どおり）。
+/// - それ以外（= server-initiated channel）→ `server_channels` registry を引き、登録 handler へ
+///   raw [`UnisonStream`] を渡す。宣言 frame は routing で消費済みなので、handler は後続
+///   payload を **直読** して reliable に受ける（recv ループ／中継 mpsc を挟まない =
+///   遅い consumer には QUIC backpressure が掛かり、取りこぼしも OOM も起きない）。
+/// - 未登録 channel → 従来どおり drop + warn（無回帰）。
 pub(crate) async fn client_accept_bi_loop(
     connection: quinn::Connection,
     identity_tx: Arc<Mutex<Option<oneshot::Sender<ProtocolMessage>>>>,
+    server_channels: ClientServerChannelRegistry,
 ) {
     loop {
         match connection.accept_bi().await {
-            Ok((_send_stream, mut recv_stream)) => {
+            Ok((send_stream, mut recv_stream)) => {
                 let identity_tx = identity_tx.clone();
+                let server_channels = Arc::clone(&server_channels);
+                let connection = connection.clone();
                 tokio::spawn(async move {
                     match read_typed_frame(&mut recv_stream).await {
                         Ok((FRAME_TYPE_PROTOCOL, frame_bytes)) => {
@@ -48,11 +73,48 @@ pub(crate) async fn client_accept_bi_loop(
                                         );
                                     }
                                 } else {
-                                    // 想定外: server-initiated stream の非 identity frame は drop
-                                    warn!(
-                                        method = %message.method,
-                                        "unexpected non-identity frame on server-initiated stream; dropping"
-                                    );
+                                    // server-initiated channel: registry を引いて handler へ
+                                    // raw UnisonStream を渡す（= server handler と対称、直読 reliable）。
+                                    let handler = {
+                                        let reg = server_channels.read().await;
+                                        reg.get(&message.method).cloned()
+                                    };
+                                    match handler {
+                                        Some(handler) => {
+                                            // client 側 quinn::Connection を transport 非依存の
+                                            // trait object へ box する（client.rs の channel open と同形）。
+                                            let conn_arc: Arc<dyn UnisonConn> =
+                                                Arc::new(connection.clone());
+                                            let stream = UnisonStream::from_streams(
+                                                0,
+                                                message.method.clone(),
+                                                conn_arc,
+                                                Box::new(send_stream),
+                                                Box::new(recv_stream),
+                                            );
+                                            if let Err(e) = handler(stream).await {
+                                                if e.is_normal_close() {
+                                                    debug!(
+                                                        channel = %message.method,
+                                                        "server channel closed normally (end of stream)"
+                                                    );
+                                                } else {
+                                                    error!(
+                                                        channel = %message.method,
+                                                        "server channel handler error: {}",
+                                                        e
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        None => {
+                                            // 未登録: 従来どおり drop + warn（無回帰）。
+                                            warn!(
+                                                method = %message.method,
+                                                "no server-channel handler registered; dropping server-initiated stream"
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -90,6 +152,10 @@ pub(crate) async fn handle_connection(
     ctx: Arc<ConnectionContext>,
 ) -> Result<()> {
     let remote_addr = connection.remote_address();
+
+    // server-initiated stream (= ServerToClient) を handler が開けるよう、ctx に conn を渡す。
+    // server 側のみ・1 行（ctx/conn はここで同居しているので call-site ripple ゼロ）。
+    ctx.set_conn(Arc::clone(&connection)).await;
 
     // v0.10.0: active connection に登録 (= server.broadcast の配信先)
     let connection_arc = Arc::clone(&connection);

--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -9,14 +9,19 @@ use anyhow::{Context, Result};
 use quinn::{ClientConfig, Connection, Endpoint, ServerConfig};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::{ClientConfig as RustlsClientConfig, ServerConfig as RustlsServerConfig};
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock, oneshot};
 use tracing::{error, info, warn};
 
 use super::conn::UnisonConn;
-use super::dispatch::{client_accept_bi_loop, handle_connection};
-use super::{ProtocolMessage, context::ConnectionContext, server::ProtocolServer};
+use super::dispatch::{
+    ClientServerChannelHandler, ClientServerChannelRegistry, client_accept_bi_loop,
+    handle_connection,
+};
+use super::{NetworkError, ProtocolMessage, context::ConnectionContext, server::ProtocolServer};
 
 // 後方互換: typed-frame wire I/O と handler-facing stream 型は専用モジュールへ
 // 移動したが、 `network::quic::*` の public import パスを保つため再公開する。
@@ -186,6 +191,11 @@ pub struct QuicClient {
     /// `TrustAnchors::SkipVerification` for backward compatibility with
     /// `QuicClient::new()` callers (will be tightened in v0.9.0).
     trust_anchors: super::trust::TrustAnchors,
+    /// server-initiated channel (= `from="server"`) の handler registry。
+    ///
+    /// `client_accept_bi_loop` が server 発信 stream の先頭宣言 frame の method で引く。
+    /// [`register_server_channel`](Self::register_server_channel) で登録。
+    server_channels: ClientServerChannelRegistry,
 }
 
 /// Builder for [`QuicClient`] (v0.8.0+).
@@ -216,6 +226,7 @@ impl QuicClientBuilder {
             identity_tx: Arc::new(Mutex::new(None)),
             response_tasks: Arc::new(Mutex::new(Vec::new())),
             trust_anchors,
+            server_channels: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 }
@@ -251,6 +262,7 @@ impl QuicClient {
             identity_tx: Arc::new(Mutex::new(None)),
             response_tasks: Arc::new(Mutex::new(Vec::new())),
             trust_anchors: super::trust::TrustAnchors::SkipVerification,
+            server_channels: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -288,6 +300,30 @@ impl QuicClient {
     /// QUIC接続への参照を取得（チャネル用ストリーム開設に使用）
     pub fn connection(&self) -> &Arc<RwLock<Option<Connection>>> {
         &self.connection
+    }
+
+    /// server-initiated channel (= `from="server"`) の handler を登録する。
+    ///
+    /// server が [`ConnectionContext::open_server_stream`](super::context::ConnectionContext::open_server_stream)
+    /// で開いた stream の先頭宣言 frame の method がこの `channel` と一致すると、handler に
+    /// raw [`UnisonStream`] が渡る。handler はその stream を **直読** して reliable に payload
+    /// を受ける（recv ループ／中継 mpsc を挟まない = 取りこぼし無し）。
+    ///
+    /// `connect` 前に登録しておくこと（接続直後に届く server-initiated stream を取りこぼさない）。
+    /// 同 `channel` で再登録すると古い handler を replace する。
+    pub async fn register_server_channel<F, Fut>(&self, channel: &str, handler: F)
+    where
+        F: Fn(UnisonStream) -> Fut + Send + Sync + 'static,
+        Fut: futures_util::Future<Output = Result<(), NetworkError>> + Send + 'static,
+    {
+        let handler: ClientServerChannelHandler = Arc::new(move |stream: UnisonStream| {
+            Box::pin(handler(stream))
+                as Pin<Box<dyn futures_util::Future<Output = Result<(), NetworkError>> + Send>>
+        });
+        self.server_channels
+            .write()
+            .await
+            .insert(channel.to_string(), handler);
     }
 }
 
@@ -372,8 +408,9 @@ impl QuicClient {
 
         // サーバー発信ストリームを受け付けるバックグラウンドタスクを起動
         let identity_tx = self.identity_tx.clone();
+        let server_channels = Arc::clone(&self.server_channels);
         let task = tokio::spawn(async move {
-            client_accept_bi_loop(connection_for_loop, identity_tx).await;
+            client_accept_bi_loop(connection_for_loop, identity_tx, server_channels).await;
         });
         self.response_tasks.lock().await.push(task);
 

--- a/crates/unison-protocol/tests/test_server_initiated_stream.rs
+++ b/crates/unison-protocol/tests/test_server_initiated_stream.rs
@@ -109,7 +109,10 @@ async fn test_server_initiated_reliable_ordered_delivery() -> Result<()> {
         got.len()
     );
     let expected: Vec<i64> = (0..N).collect();
-    assert_eq!(got, expected, "同順で届くべき（単一 QUIC stream の順序保証）");
+    assert_eq!(
+        got, expected,
+        "同順で届くべき（単一 QUIC stream の順序保証）"
+    );
 
     // ─── Cleanup ───────────────────────────────────────
     client.disconnect().await?;

--- a/crates/unison-protocol/tests/test_server_initiated_stream.rs
+++ b/crates/unison-protocol/tests/test_server_initiated_stream.rs
@@ -1,0 +1,172 @@
+//! Medium x Integration: server-initiated reliable stream（1.5.0）
+//!
+//! `ConnectionContext::open_server_stream`（server 起点で stream を開く）+
+//! `ProtocolClient::register_server_channel`（client が raw `UnisonStream` handler を登録）が
+//! end-to-end で繋がり、**取りこぼし無し・同順**で配送されることを QUIC ペアで検証する。
+//!
+//! 設計: `design/server-initiated-stream.md`（対称化路線 = client handler も server と同じ
+//! raw `UnisonStream` を直読する → recv ループ／中継 mpsc を挟まないので drop も OOM も起きない）。
+//!
+//! `#[ignore]` 付き — `cargo test -- --ignored` で実行（QUIC runtime が要る）。
+
+use anyhow::Result;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+use tracing::Level;
+
+use unison::network::context::ConnectionContext;
+use unison::network::{ConnectionEvent, MessageType, ProtocolMessage};
+use unison::{ProtocolClient, ProtocolServer};
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_test_writer()
+        .try_init();
+}
+
+/// Connected event を待って、その connection の ctx を取り出す。
+async fn wait_for_ctx(
+    events: &mut unison::network::ConnectionEventReceiver,
+) -> Arc<ConnectionContext> {
+    loop {
+        match events.recv().await.expect("connection event") {
+            ConnectionEvent::Connected { context, .. } => return context,
+            ConnectionEvent::Disconnected { .. } => continue,
+        }
+    }
+}
+
+/// server が `open_server_stream` で push した N 件を、client handler が
+/// **全件・同順**で受信する（reliable server→client）。
+#[tokio::test]
+#[ignore = "Medium: requires QUIC runtime"]
+async fn test_server_initiated_reliable_ordered_delivery() -> Result<()> {
+    init_tracing();
+    const N: i64 = 200;
+
+    // ─── Server setup ──────────────────────────────────
+    let server = Arc::new(ProtocolServer::new());
+    let mut events = server.subscribe_connection_events();
+    let handle = Arc::clone(&server).spawn_listen_shared("[::1]:0").await?;
+    let addr = handle.local_addr();
+
+    // ─── Client: handler を connect 前に登録 ────────────
+    let (tx, mut rx) = mpsc::unbounded_channel::<i64>();
+    let client = ProtocolClient::new_default()?;
+    client
+        .register_server_channel("relay", move |stream| {
+            let tx = tx.clone();
+            async move {
+                // raw UnisonStream を直読（= QUIC backpressure、取りこぼし無し）
+                loop {
+                    match stream.recv_frame().await {
+                        Ok(msg) => {
+                            let v = msg.payload_as_value()?;
+                            let seq = v.get("seq").and_then(|s| s.as_i64()).unwrap_or(-1);
+                            let _ = tx.send(seq);
+                        }
+                        Err(_) => break, // end of stream（server が close）
+                    }
+                }
+                Ok(())
+            }
+        })
+        .await;
+    client
+        .connect(&format!("[{}]:{}", addr.ip(), addr.port()))
+        .await?;
+
+    // ─── Server: ctx を得て reliable push stream に N 件送る ──
+    let ctx = wait_for_ctx(&mut events).await;
+    let stream = ctx.open_server_stream("relay").await?;
+    for i in 0..N {
+        let msg = ProtocolMessage::new_with_json(
+            0,
+            "msg".to_string(),
+            MessageType::Event,
+            serde_json::json!({ "seq": i }),
+        )?;
+        stream.send_frame(&msg).await?;
+    }
+
+    // ─── Client: 全件を順序どおり受信 ──────────────────
+    let mut got = Vec::new();
+    for _ in 0..N {
+        match timeout(Duration::from_secs(5), rx.recv()).await {
+            Ok(Some(seq)) => got.push(seq),
+            Ok(None) => break, // sender 終了
+            Err(_) => break,   // timeout
+        }
+    }
+
+    assert_eq!(
+        got.len() as i64,
+        N,
+        "全 {N} 件が reliable に届くべき（取りこぼし無し）。received={}",
+        got.len()
+    );
+    let expected: Vec<i64> = (0..N).collect();
+    assert_eq!(got, expected, "同順で届くべき（単一 QUIC stream の順序保証）");
+
+    // ─── Cleanup ───────────────────────────────────────
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}
+
+/// handler 未登録の channel へ push しても、client は drop + warn するだけで
+/// 接続は壊れない（後方互換 = 無回帰）。
+#[tokio::test]
+#[ignore = "Medium: requires QUIC runtime"]
+async fn test_server_initiated_unregistered_channel_no_regression() -> Result<()> {
+    init_tracing();
+
+    let server = Arc::new(ProtocolServer::new());
+    let mut events = server.subscribe_connection_events();
+    let handle = Arc::clone(&server).spawn_listen_shared("[::1]:0").await?;
+    let addr = handle.local_addr();
+
+    let client = ProtocolClient::new_default()?;
+    // handler は登録しない
+    client
+        .connect(&format!("[{}]:{}", addr.ip(), addr.port()))
+        .await?;
+
+    let ctx = wait_for_ctx(&mut events).await;
+
+    // 未登録 channel へ push → client 側は drop + warn（panic しない）
+    let stream = ctx.open_server_stream("no-handler").await?;
+    let msg = ProtocolMessage::new_with_json(
+        0,
+        "x".to_string(),
+        MessageType::Event,
+        serde_json::json!({}),
+    )?;
+    stream.send_frame(&msg).await?;
+
+    // 接続は維持されている: connect 時に受けた identity が依然取得できる
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        client.server_identity().await.is_some(),
+        "未登録 server stream を drop しても接続は壊れない"
+    );
+
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}
+
+/// client 側 ctx（conn 未 set）で `open_server_stream` を呼ぶと誤用として error。
+/// QUIC runtime 不要。
+#[tokio::test]
+async fn test_open_server_stream_on_client_ctx_is_misuse_error() {
+    let ctx = ConnectionContext::new();
+    let res = ctx.open_server_stream("x").await;
+    assert!(
+        res.is_err(),
+        "conn 未 set の ctx（client 側）では open_server_stream は誤用 error になるべき"
+    );
+}

--- a/design/server-initiated-stream.md
+++ b/design/server-initiated-stream.md
@@ -1,31 +1,64 @@
 # Server-Initiated Stream — `ServerToClient` 方向を起こす（reliable server→client）
 
-**status**: 設計確定 2026-06-28 / 1.5.0 実装中
+**status**: 設計確定 2026-06-28 / 対称化路線へ再構成 2026-06-28 / 1.5.0 実装中
 **動機元**: chronista-hub federation relay（ADR-020 §S4）— hub が world A の bytes を world B の既存 connection へ **reliable** に forward する floor が要る。
-**原則**: Occam — 新 transport 概念を増やさず、**既に宣言されているが眠っている `ChannelDirection::ServerToClient` を honor する**だけ。
+**原則**: Occam — 新 transport 概念を増やさず、**既に宣言されているが眠っている `ChannelDirection::ServerToClient` を honor する**だけ。さらに本改訂では、reliable を「新しい配送 mode」ではなく **server / client の受信 handler を対称化する**ことで構造的に得る。
 
 ---
 
-## 1. 何が欠けているか
+## 1. message の 2 軸モデル — なぜ `ServerToClient` が要るか
 
-club-unison の現状（1.4.0）:
+inter-agent / relay の通信を 2 つの**直交する軸**で捉えると、欠けているものが 1 つに絞れる。
 
-- **`ChannelDirection::ServerToClient` は型にも KDL（`from="server"`）にも既出**だが、`build_identity()` が常に `Bidirectional` をハードコードし runtime で無視している。
-- server→client の唯一の経路 = **client が開いた persistent channel 上で `UnisonChannel::send_event`**。これは設計どおり（`dispatch.rs`「server→client 通信は client が開いた channel 上で行う」）だが、**意図的に best-effort**: recv demux が event を `try_send`・buffer 256・full で **drop + warn**（Response path を HoL させないため、`channel.rs` の `try_deliver`）。
-- 帰結: **reliable な server→client 配送が無い**。Request/Response（oneshot）だけが reliable で、それは client→server 起点に限る。
+- **interaction 軸**: 一方向（fire-and-forget）/ 往復（request_id で相関する req↔resp）
+  - 往復は transport の別 mode ではなく「correlation_id で結んだ 2 本の一方向 message」= 規約。`UnisonChannel` の pending oneshot map がこれを実装している。
+- **QoS 軸**: best-effort（落ちてよい）/ reliable（落ちてはいけない）
 
-relay のように「server 起点で取りこぼせない stream」を運ぶ用途には、best-effort event では不十分（backpressure 下で drop → 上位の再送 churn）。
+|              | best-effort（落ちてOK）          | reliable（落ちてはNG）                       |
+| ------------ | -------------------------------- | -------------------------------------------- |
+| **一方向**   | telemetry / position → datagram  | **relay msg ← ここだけ実装が無い**            |
+| **往復**     | （ほぼ無意味）                   | req↔resp（応答脚は本質 reliable）→ 実装済み   |
 
-## 2. 既にある材料
+→ 4 セル中 3 つは既にある。**欠けているのは「一方向 × reliable」の 1 セルだけ**で、それを **server 起点で**開けるようにするのが本 primitive。これは型・KDL に既出の `ChannelDirection::ServerToClient`（`from="server"`）そのものを指す。
 
-- **`UnisonConn::open_bi() -> BiStream`**（`conn.rs`）は **server からも stream を開ける**。現に identity 送信が `connection.open_bi()` で server-initiated stream を1本開いている（`dispatch.rs`）。
+### lane モデル（QoS クラス = stream を分ける）
+
+QUIC の idiom「用途ごとに stream を分ける（= 独立 HoL 境界）」に従い、QoS クラスごとにレーンを割る:
+
+| lane                          | transport                  | 信頼性 / 順序            | 用途                       | 現状     |
+| ----------------------------- | -------------------------- | ----------------------- | -------------------------- | -------- |
+| real-time state               | datagram                   | best-effort / 無順序     | position / rotation        | 稼働中   |
+| continuous media              | raw frame・専用 stream     | reliable / 同順          | audio                      | 予約     |
+| **app protocol**              | structured 0x00・専用 stream | reliable / 同順          | req↔resp + 意味のある event | 稼働中（client 開設のみ）／**本 primitive で server 起点を追加** |
+
+**帰結**: best-effort(drop) は datagram に隔離される。**stream lane に best-effort が残る理由は無く、stream lane は全部 reliable であるべき**。`send_event` の `try_send`-drop は「telemetry を structured lane に混ぜていた時代の遺物」と位置づける（§4 / §7）。
+
+---
+
+## 2. 何が欠けているか（現状 1.4.0）
+
+- **`ChannelDirection::ServerToClient` は型にも KDL（`from="server"`）にも既出**だが、`build_identity()`（`network/server.rs:208`）が常に `Bidirectional` をハードコードし runtime で無視している。
+- server→client の唯一の経路 = **client が開いた persistent channel 上で `UnisonChannel::send_event`**。これは `dispatch.rs`「server→client 通信は client が開いた channel 上で行う」どおりだが、**意図的に best-effort**: client 側 `UnisonChannel` の recv ループが event を `try_send`・buffer 256・full で **drop + warn**（`channel.rs:74-85` の `try_deliver`）。
+- 帰結: **reliable な server-initiated 配送が無い**。
+
+relay のように「server 起点で取りこぼせない stream」を運ぶ用途には best-effort event では不十分（backpressure 下で drop → 上位の再送 churn）。
+
+---
+
+## 3. 既にある材料
+
+- **`UnisonConn::open_bi() -> BiStream`**（`conn.rs`）は **server からも stream を開ける**。現に identity 送信が `connection.open_bi()` で server-initiated stream を 1 本開いている（`dispatch.rs:133`）。
   → **「server が stream を開く動詞」は新設不要**。
-- client 側 `client_accept_bi_loop`（`dispatch.rs`）は server-initiated bi stream を `accept_bi()` で受けているが、**先頭 frame の method が `__identity` 以外は drop** している。
+- **server 側 channel handler は既に raw `UnisonStream` を直接 read している**（`dispatch.rs:222-229` で `UnisonStream::from_streams` を作って `handler(ctx, stream)`、discovery handler も同様）。
+  → これが**対称化の土台**。reliable な受信の「正解の形」は既に server 側に実在する（§4）。
+- client 側 `client_accept_bi_loop`（`dispatch.rs:27`）は server-initiated bi stream を `accept_bi()` で受けているが、**先頭 frame の method が `__identity` 以外は drop** している。
   → routing を一般化すれば、宣言済みの server-push channel に配れる。
 
-## 3. 最小 primitive（対称2編集）
+---
 
-新概念ゼロ。`ServerToClient` を本物にする2点だけ。
+## 4. 設計：対称化（client handler も raw `UnisonStream` を受け取る）
+
+新概念ゼロ。`ServerToClient` を本物にする対称 2 編集だけ。
 
 ### ① server 側 — handler が server-initiated stream を開けるようにする
 
@@ -33,63 +66,104 @@ relay のように「server 起点で取りこぼせない stream」を運ぶ用
 
 ```rust
 // ConnectionContext
-conn: Arc<dyn UnisonConn>,   // 追加（既に handle_connection で利用可能）
+conn: Arc<RwLock<Option<Arc<dyn UnisonConn>>>>,   // 追加（init None、server 側のみ set される）
 
 /// server 起点で reliable な双方向 stream を開き、宣言 channel として frame する。
-/// 中身は既存 conn.open_bi() + 先頭に channel 宣言 frame（__identity と同じ要領）。
-pub async fn open_server_stream(&self, channel: &str) -> Result<UnisonChannel, NetworkError>;
+/// 中身は既存 conn.open_bi() + 先頭に channel 宣言 frame（__identity と同要領）。
+/// finish() はしない（persistent stream）。
+pub async fn open_server_stream(&self, channel: &str) -> Result<UnisonStream, NetworkError>;
 ```
 
-- 返る `UnisonChannel` は **dedicated QUIC stream**（flow-control 内蔵 = reliable・取りこぼさない）。
+- 返るのは **`UnisonStream`（raw）** であって `UnisonChannel` ではない。これが対称化の肝。
 - `channel` 名は client 側の `from="server"` handler 解決キー。
 
 ### ② client 側 — server-initiated stream を宣言 channel handler へ routing
 
-client が **server-push channel handler を登録**できるようにし、`client_accept_bi_loop` が先頭 frame の channel/method で振り分ける（`__identity` は従来どおり専用 oneshot、それ以外は登録 handler へ、未登録なら従来どおり drop+warn）:
+client が **server-push channel handler を登録**できるようにし、handler には **`UnisonStream`（raw）を渡す**（= server handler と同じ面）:
 
 ```rust
 // ProtocolClient
 pub async fn register_server_channel<F>(&self, channel: &str, handler: F)
-where F: Fn(UnisonChannel) -> BoxFuture<'static, Result<()>> + Send + Sync + 'static;
+where F: Fn(UnisonStream) -> BoxFuture<'static, Result<()>> + Send + Sync + 'static;
 ```
 
-→ `from="server"` channel を declared に受理。`__identity` の特別扱いはこの一般機構の一例に縮約される（既存挙動は不変）。
+`client_accept_bi_loop` が先頭 frame の method で振り分ける（`__identity` は従来どおり専用 oneshot、それ以外は registry を引いて handler へ `UnisonStream` を渡す、未登録なら従来どおり drop+warn）。
 
-## 4. 意図的に**足さない**もの（剃刀）
+### なぜ `UnisonStream`（直読）であって `UnisonChannel::new_reliable`（mpsc + `send().await`）でないか
 
-- **`get_connection_by_principal` / connection lookup table は substrate に置かない**。「どの principal/id が誰か」は **application の関心**。利用側（hub）が自分で `key → Arc<UnisonConn>`（or ctx）map を持つ。substrate は「この connection に server stream を開く」だけを提供する。
-- **relay 専用 API も置かない**。relay は利用側の composition。substrate は汎用の server-initiated stream のみ。
-- 新しい transport 動詞（`open_bi` 以外）を増やさない。
+- **reliable の正解は actor / 直読**。handler 自身のタスクが `stream.recv_typed_frame().await` を順に読む。**recv_task も中継 mpsc も無いので drop が原理的に起きず、deadlock も起きない**（1 task が Response も event も順に捌く）。server 側が既にこの形。
+- 対して `UnisonChannel`（client 側）の `try_send`-drop は、**req↔resp と event を 1 本に混ぜた共有 channel**で「event 配送を block すると後ろの Response が詰まる」HoL/deadlock を避けるためのブレーカー。**ここを global に `send().await` へ flip すると deadlock が戻る**（drain loop の中で `request().await` して park → event が溜まる → recv_task が block → その request の Response が読めず詰む）。
+- つまり drop は **client 側 mpsc bridge の遺物**であり、寄せるべき先は「mpsc を blocking 化」ではなく「**mpsc を外して server と同じ直読に揃える**」。本 primitive はその対称化を server-initiated stream について行う。
+- 既存 client `open_channel` → `UnisonChannel`(drop) は**触らない**。client 全体を直読（actor）へ寄せる完全 unification は north star（§7）。
 
-## 5. framing / 後方互換
+---
 
-- server-initiated stream の先頭 frame で channel/method を宣言（`__identity` と同形）。client はそれで handler を解決。
+## 5. reliability の根拠
+
+`★ 完全性は queue でなく end-to-end backpressure（QUIC flow control）が生む。`
+
+- handler が `recv_typed_frame()` を**読まない間**、QUIC の受信 window が埋まる → QUIC が送信側へ flow control → 送信側（hub）の write が block。backpressure が network 越しに送信元まで伝播する。
+- **1 byte も落とさず**、メモリは QUIC stream window で**有界**。
+- best-effort event（`try_send` drop）との違いはここ: dedicated QUIC stream + 直読は「詰まったら drop」でなく「詰まったら遡って throttle」。これが §S4 で Arch B でなく A を選んだ核心。
+- queue 単体（bounded→drop / unbounded→OOM）では完全性は出ない。QUIC を底に敷いて初めて「有界 × 無損失」が成立する。
+
+---
+
+## 6. framing / 後方互換
+
+- server-initiated stream の先頭 frame で channel/method を宣言（`__identity` と同形 = `FRAME_TYPE_PROTOCOL` の `ProtocolMessage`、method = channel 名）。client はそれで handler を解決し、**宣言 frame は routing で消費**、handler は後続 payload を読む（server 側の channel open と同じ要領）。
+- client 側 routing: 先頭 frame の method が `__identity` → 従来の oneshot、それ以外 → registry 引き、未登録なら従来どおり **drop + warn**（無回帰）。
 - **additive**: 既存の client-opened channel・`send_event`・request/response は不変。`from="server"` handler を登録しない client は server-push stream を従来どおり drop（無回帰）。
-- `build_identity()` は `from="server"` を honor して `ServerToClient` を返すよう更新（schema と runtime の齟齬解消、自己記述 discovery が正しくなる）。
+- `build_identity()` は `from="server"` を honor して `ServerToClient` を返すよう更新（schema↔runtime 齟齬解消）。**二次的**で、server 側に server-push channel の direction 真実が無い現状（`register_channel` に direction 引数が無い）では read 元の整備が前提（§8）。
 
-## 6. reliability の根拠
+---
 
-dedicated QUIC stream は per-stream flow-control を持つ → 送り手は drop せず **backpressure で slow down**。best-effort event（`try_send` drop）と違い relay payload を取りこぼさない。これが §S4 で Arch B でなく A を選んだ核心。
+## 7. 意図的に**足さない**もの（剃刀）
 
-## 7. version
+- **`get_connection_by_principal` / connection lookup table は substrate に置かない**。「どの principal/id が誰か」は application の関心。利用側（hub）が `wld_id → ctx`（or `Arc<UnisonConn>`）map を持ち、`ctx.open_server_stream()` を呼ぶ。
+- **relay 専用 API も置かない**。relay は利用側の composition。substrate は汎用の server-initiated stream のみ。
+- **新しい transport 動詞（`open_bi` 以外）を増やさない。**
+- **aggregate（1 request → N response 等の多重相関）は作らない**。pending を `oneshot | mpsc` に一般化する必要が出るが、consumer が現れるまで保留。本 primitive のスコープ外。
+- **既存 client `UnisonChannel` の global reliable 化（actor/直読への全面 unification）はやらない**。relay でパターンが実証できた後の north star。1.5.0 は server-initiated handler の対称化に閉じる。
+
+---
+
+## 8. 既知の制約 / 実装時の落とし穴
+
+- **client 受信経路は raw QUIC 専用**。`client_accept_bi_loop`（`dispatch.rs:27`、起動 `quic.rs:376`）は `quinn::Connection` 直で、`Arc<dyn UnisonConn>` を貫通していない。→ **WebTransport（ブラウザ）client は server-initiated channel を受けられない**（native/quinn client は OK）。`UnisonStream::from_streams` に渡す `Arc<dyn UnisonConn>` は `Arc::new(connection.clone())` で作れる（既に `client.rs:212` で使う pattern）。透過の完全化は別 issue。
+- **server-initiated stream に nack（配送失敗シグナル）が無い**。client-opened channel は open_ack/nack を持つ（`dispatch.rs:206` / `client.rs:190`）が、server-initiated は宣言 frame を書いて流すだけ。client が handler 未登録なら drop + warn で、**server は失敗を知れない**（silent blackhole）。relay は「downstream が handler を登録済み」を前提に運用する。明示 ack が必要になったら別途。
+- **`client_accept_bi_loop` は現状 1 frame 読んで task 終了 + `_send_stream` を破棄**（`dispatch.rs:33`）。identity は 1 frame で正だが、persistent server channel 化には **send_stream を保持**して `UnisonStream::from_streams` に渡し、handler に**継続 read**させる必要。
+- **`ConnectionContext` の `#[derive(Debug)]`**: `UnisonConn` は Debug 非実装（`conn.rs:71`）なので、conn field を持たせると derive が壊れる → **手書き Debug**（conn を skip）へ。
+- **`conn` は `Option` + `set_conn`**: ctx 生成は 3 つの server ingress に散る（`webtransport.rs:314` / `quic.rs:638,672`）が、全て `handle_connection` に収束するので、そこで `set_conn` 1 行で足りる（call-site ripple ゼロ）。client ctx（`client.rs:98,117`）は conn=None のままで `open_server_stream` が error → 正しい誤用検知。
+
+---
+
+## 9. version
 
 **1.5.0**（minor・additive）。下流（chronista-hub relay / VP dialer・target inbound）はこの上に composition で乗る。
 
-## 8. 実装 checklist（1.5.0、この repo で実施）
+---
+
+## 10. 実装 checklist（1.5.0、この repo で実施）
 
 > handoff 元: chronista-hub federation session（2026-06-28）。本 doc が SSOT。下流 = chronista-hub relay（§S4）/ VP dialer は 1.5.0 release 後に乗る。
 
-1. **`network/context.rs`** — `ConnectionContext` に `conn: Arc<RwLock<Option<Arc<dyn UnisonConn>>>>`（init None）+ `set_conn(conn)` + `open_server_stream(channel) -> Result<UnisonChannel>`。`open_server_stream` = `conn.open_bi()` →（宣言 frame を `write_typed_frame` で1本書く、`__identity` 送信と同形 = `dispatch.rs::handle_connection` L129-140 参照）→ `UnisonStream::from_streams` → `UnisonChannel::new`。conn が None なら error（client 誤用）。`#[derive(Debug)]` は `UnisonConn` 非 Debug なので**手書き Debug** へ（conn field を skip）。
-2. **`network/dispatch.rs`** — `handle_connection` 冒頭で `ctx.set_conn(Arc::clone(&connection)).await`（**server 側のみ・1行**。call-site ripple ゼロ = ctx/conn は既にここで同居）。`client_accept_bi_loop` を一般化: 先頭 frame の method が `__identity` → 従来の oneshot、それ以外 → client 側 server-channel registry を引いて handler へ（`UnisonChannel` 化して渡す）、**未登録なら従来どおり drop+warn**（無回帰）。
-3. **`network/client.rs`** — `ProtocolClient` に server-channel handler registry（`Arc<RwLock<HashMap<String, Handler>>>`）+ `register_server_channel(channel, handler)`。`client_accept_bi_loop` 起動箇所（`quic.rs` L376）へ registry を渡す。
-4. **`network/identity.rs` / `server.rs`** — `build_identity()` が `from="server"` を honor して `ChannelDirection::ServerToClient` を返す（schema↔runtime 齟齬解消、二次的）。
-5. **tests** — server が `open_server_stream("x")` → client の `register_server_channel("x", ...)` handler が **reliable に受信**（取りこぼし無し round-trip）。後方互換: handler 未登録 client は従来 drop。
+1. **`network/context.rs`** — `ConnectionContext` に `conn: Arc<RwLock<Option<Arc<dyn UnisonConn>>>>`（init None）+ `set_conn(conn)` + `open_server_stream(channel) -> Result<UnisonStream>`。`open_server_stream` = `conn.open_bi()` →（宣言 frame を `write_typed_frame` で 1 本書く、`__identity` 送信と同形 = `dispatch.rs::handle_connection` 参照、**`finish()` しない**）→ `UnisonStream::from_streams`。conn が None なら error（client 誤用）。`#[derive(Debug)]` → conn を skip した**手書き Debug**へ。
+2. **`network/dispatch.rs`** — `handle_connection` 冒頭で `ctx.set_conn(Arc::clone(&connection)).await`（**server 側のみ・1 行**）。`client_accept_bi_loop` を一般化: 先頭 frame の method が `__identity` → 従来 oneshot、それ以外 → client 側 server-channel registry を引いて handler へ **`UnisonStream` を渡す**（**send_stream を保持**し、`Arc::new(connection.clone())` で `Arc<dyn UnisonConn>` を作って `from_streams`）、**未登録なら drop+warn**（無回帰）。
+3. **`network/client.rs`** — `ProtocolClient` に server-channel handler registry（`Arc<RwLock<HashMap<String, Handler>>>`、`Handler = Fn(UnisonStream) -> BoxFuture<...>`）+ `register_server_channel(channel, handler)`。`client_accept_bi_loop` 起動箇所（`quic.rs:376`）へ registry を渡す。
+4. **`network/identity.rs` / `server.rs`** — `build_identity()` が `from="server"` を honor して `ChannelDirection::ServerToClient` を返す（**二次的**、direction の read 元整備が前提）。
+5. **tests** —
+   - server が `open_server_stream("x")` → client の `register_server_channel("x", ...)` handler が **reliable に受信**（取りこぼし無し round-trip）。
+   - **backpressure**: handler が読まないと送信側 write が throttle され、**drop が起きない**（unbounded 成長もしない）。
+   - 後方互換: handler 未登録 client は従来 drop+warn。
 6. **version** — workspace `Cargo.toml` 1.4.0 → **1.5.0**（minor・additive）。CHANGELOG。
 
-**剃刀の不変条件**（実装中に侵さないこと）: `get_connection_by_principal` 等の lookup table を substrate に置かない（利用側=hub が `wld_id→conn` map を持つ）。relay 専用 API も置かない（relay は利用側 composition）。新 transport 動詞を増やさない（`open_bi` 既存）。
+**剃刀の不変条件**（実装中に侵さないこと）: `get_connection_by_principal` 等の lookup table を substrate に置かない（利用側=hub が `wld_id→ctx` map を持つ）。relay 専用 API も置かない。新 transport 動詞を増やさない（`open_bi` 既存）。aggregate / 既存 `UnisonChannel` の global reliable 化はスコープ外。
+
+---
 
 ## References
 
 - chronista-hub ADR-020 §S4（relay = universal floor、本 primitive の利用側）
-- `design/connection-auth.md`（connection-level の principal — relay の wld_id↔conn map は利用側がこの principal を keyに持つ）
-- `network/dispatch.rs`（`client_accept_bi_loop` / `handle_connection`）/ `network/conn.rs`（`UnisonConn::open_bi`）/ `network/context.rs`（`ConnectionContext`）/ `network/channel.rs`（`send_event` best-effort demux）
+- `design/connection-auth.md`（connection-level の principal — relay の `wld_id↔conn` map は利用側がこの principal を key に持つ）
+- `network/dispatch.rs`（`client_accept_bi_loop` / `handle_connection`）/ `network/conn.rs`（`UnisonConn::open_bi`）/ `network/context.rs`（`ConnectionContext`）/ `network/stream.rs`（`UnisonStream` = 直読の reliable 面）/ `network/channel.rs`（`UnisonChannel` の `try_send` best-effort demux = 触らない既存）

--- a/design/server-initiated-stream.md
+++ b/design/server-initiated-stream.md
@@ -1,0 +1,95 @@
+# Server-Initiated Stream — `ServerToClient` 方向を起こす（reliable server→client）
+
+**status**: 設計確定 2026-06-28 / 1.5.0 実装中
+**動機元**: chronista-hub federation relay（ADR-020 §S4）— hub が world A の bytes を world B の既存 connection へ **reliable** に forward する floor が要る。
+**原則**: Occam — 新 transport 概念を増やさず、**既に宣言されているが眠っている `ChannelDirection::ServerToClient` を honor する**だけ。
+
+---
+
+## 1. 何が欠けているか
+
+club-unison の現状（1.4.0）:
+
+- **`ChannelDirection::ServerToClient` は型にも KDL（`from="server"`）にも既出**だが、`build_identity()` が常に `Bidirectional` をハードコードし runtime で無視している。
+- server→client の唯一の経路 = **client が開いた persistent channel 上で `UnisonChannel::send_event`**。これは設計どおり（`dispatch.rs`「server→client 通信は client が開いた channel 上で行う」）だが、**意図的に best-effort**: recv demux が event を `try_send`・buffer 256・full で **drop + warn**（Response path を HoL させないため、`channel.rs` の `try_deliver`）。
+- 帰結: **reliable な server→client 配送が無い**。Request/Response（oneshot）だけが reliable で、それは client→server 起点に限る。
+
+relay のように「server 起点で取りこぼせない stream」を運ぶ用途には、best-effort event では不十分（backpressure 下で drop → 上位の再送 churn）。
+
+## 2. 既にある材料
+
+- **`UnisonConn::open_bi() -> BiStream`**（`conn.rs`）は **server からも stream を開ける**。現に identity 送信が `connection.open_bi()` で server-initiated stream を1本開いている（`dispatch.rs`）。
+  → **「server が stream を開く動詞」は新設不要**。
+- client 側 `client_accept_bi_loop`（`dispatch.rs`）は server-initiated bi stream を `accept_bi()` で受けているが、**先頭 frame の method が `__identity` 以外は drop** している。
+  → routing を一般化すれば、宣言済みの server-push channel に配れる。
+
+## 3. 最小 primitive（対称2編集）
+
+新概念ゼロ。`ServerToClient` を本物にする2点だけ。
+
+### ① server 側 — handler が server-initiated stream を開けるようにする
+
+`ConnectionContext` に connection を持たせ（ctx を作る `dispatch.rs::handle_connection` で `Arc<dyn UnisonConn>` は手元にある）、handler から reliable stream を開く verb を生やす:
+
+```rust
+// ConnectionContext
+conn: Arc<dyn UnisonConn>,   // 追加（既に handle_connection で利用可能）
+
+/// server 起点で reliable な双方向 stream を開き、宣言 channel として frame する。
+/// 中身は既存 conn.open_bi() + 先頭に channel 宣言 frame（__identity と同じ要領）。
+pub async fn open_server_stream(&self, channel: &str) -> Result<UnisonChannel, NetworkError>;
+```
+
+- 返る `UnisonChannel` は **dedicated QUIC stream**（flow-control 内蔵 = reliable・取りこぼさない）。
+- `channel` 名は client 側の `from="server"` handler 解決キー。
+
+### ② client 側 — server-initiated stream を宣言 channel handler へ routing
+
+client が **server-push channel handler を登録**できるようにし、`client_accept_bi_loop` が先頭 frame の channel/method で振り分ける（`__identity` は従来どおり専用 oneshot、それ以外は登録 handler へ、未登録なら従来どおり drop+warn）:
+
+```rust
+// ProtocolClient
+pub async fn register_server_channel<F>(&self, channel: &str, handler: F)
+where F: Fn(UnisonChannel) -> BoxFuture<'static, Result<()>> + Send + Sync + 'static;
+```
+
+→ `from="server"` channel を declared に受理。`__identity` の特別扱いはこの一般機構の一例に縮約される（既存挙動は不変）。
+
+## 4. 意図的に**足さない**もの（剃刀）
+
+- **`get_connection_by_principal` / connection lookup table は substrate に置かない**。「どの principal/id が誰か」は **application の関心**。利用側（hub）が自分で `key → Arc<UnisonConn>`（or ctx）map を持つ。substrate は「この connection に server stream を開く」だけを提供する。
+- **relay 専用 API も置かない**。relay は利用側の composition。substrate は汎用の server-initiated stream のみ。
+- 新しい transport 動詞（`open_bi` 以外）を増やさない。
+
+## 5. framing / 後方互換
+
+- server-initiated stream の先頭 frame で channel/method を宣言（`__identity` と同形）。client はそれで handler を解決。
+- **additive**: 既存の client-opened channel・`send_event`・request/response は不変。`from="server"` handler を登録しない client は server-push stream を従来どおり drop（無回帰）。
+- `build_identity()` は `from="server"` を honor して `ServerToClient` を返すよう更新（schema と runtime の齟齬解消、自己記述 discovery が正しくなる）。
+
+## 6. reliability の根拠
+
+dedicated QUIC stream は per-stream flow-control を持つ → 送り手は drop せず **backpressure で slow down**。best-effort event（`try_send` drop）と違い relay payload を取りこぼさない。これが §S4 で Arch B でなく A を選んだ核心。
+
+## 7. version
+
+**1.5.0**（minor・additive）。下流（chronista-hub relay / VP dialer・target inbound）はこの上に composition で乗る。
+
+## 8. 実装 checklist（1.5.0、この repo で実施）
+
+> handoff 元: chronista-hub federation session（2026-06-28）。本 doc が SSOT。下流 = chronista-hub relay（§S4）/ VP dialer は 1.5.0 release 後に乗る。
+
+1. **`network/context.rs`** — `ConnectionContext` に `conn: Arc<RwLock<Option<Arc<dyn UnisonConn>>>>`（init None）+ `set_conn(conn)` + `open_server_stream(channel) -> Result<UnisonChannel>`。`open_server_stream` = `conn.open_bi()` →（宣言 frame を `write_typed_frame` で1本書く、`__identity` 送信と同形 = `dispatch.rs::handle_connection` L129-140 参照）→ `UnisonStream::from_streams` → `UnisonChannel::new`。conn が None なら error（client 誤用）。`#[derive(Debug)]` は `UnisonConn` 非 Debug なので**手書き Debug** へ（conn field を skip）。
+2. **`network/dispatch.rs`** — `handle_connection` 冒頭で `ctx.set_conn(Arc::clone(&connection)).await`（**server 側のみ・1行**。call-site ripple ゼロ = ctx/conn は既にここで同居）。`client_accept_bi_loop` を一般化: 先頭 frame の method が `__identity` → 従来の oneshot、それ以外 → client 側 server-channel registry を引いて handler へ（`UnisonChannel` 化して渡す）、**未登録なら従来どおり drop+warn**（無回帰）。
+3. **`network/client.rs`** — `ProtocolClient` に server-channel handler registry（`Arc<RwLock<HashMap<String, Handler>>>`）+ `register_server_channel(channel, handler)`。`client_accept_bi_loop` 起動箇所（`quic.rs` L376）へ registry を渡す。
+4. **`network/identity.rs` / `server.rs`** — `build_identity()` が `from="server"` を honor して `ChannelDirection::ServerToClient` を返す（schema↔runtime 齟齬解消、二次的）。
+5. **tests** — server が `open_server_stream("x")` → client の `register_server_channel("x", ...)` handler が **reliable に受信**（取りこぼし無し round-trip）。後方互換: handler 未登録 client は従来 drop。
+6. **version** — workspace `Cargo.toml` 1.4.0 → **1.5.0**（minor・additive）。CHANGELOG。
+
+**剃刀の不変条件**（実装中に侵さないこと）: `get_connection_by_principal` 等の lookup table を substrate に置かない（利用側=hub が `wld_id→conn` map を持つ）。relay 専用 API も置かない（relay は利用側 composition）。新 transport 動詞を増やさない（`open_bi` 既存）。
+
+## References
+
+- chronista-hub ADR-020 §S4（relay = universal floor、本 primitive の利用側）
+- `design/connection-auth.md`（connection-level の principal — relay の wld_id↔conn map は利用側がこの principal を keyに持つ）
+- `network/dispatch.rs`（`client_accept_bi_loop` / `handle_connection`）/ `network/conn.rs`（`UnisonConn::open_bi`）/ `network/context.rs`（`ConnectionContext`）/ `network/channel.rs`（`send_event` best-effort demux）


### PR DESCRIPTION
## 概要

server 起点で connected client へ **reliable・同順** な stream を開く primitive を追加（1.5.0）。既に型・KDL (`from="server"`) に宣言されながら runtime で無視されていた `ChannelDirection::ServerToClient` を本物にする。chronista-hub federation relay (ADR-020 §S4) の substrate floor。

**SemVer minor**（additive・opt-in・既存 API 不変・非破壊）。設計 SSOT: `design/server-initiated-stream.md`

## 設計の核（対称化路線）

reliable は新しい配送 mode ではなく、**client 側の受信 handler を server 側と対称化**して構造的に得る:
- server handler = `register_channel` → raw `UnisonStream` を直読（既存）
- client handler = `register_server_channel` → **同じく raw `UnisonStream` を直読**（本 PR）

recv ループ／中継 mpsc を挟まないので、遅い consumer には QUIC flow-control backpressure が掛かり、**取りこぼしも OOM も起きない**。完全性は queue (bounded→drop / unbounded→OOM) でなく **end-to-end backpressure** が生む。

## 変更

- **`context.rs`**: `ConnectionContext` に `conn`(Option) + `set_conn` + `open_server_stream(channel) -> UnisonStream`。`conn` は `dyn UnisonConn`(非 Debug) のため手書き Debug。client ctx は conn 未 set で誤用 error。
- **`dispatch.rs`**: `handle_connection` で `set_conn`（1 行）。`client_accept_bi_loop` を一般化 — 先頭 frame method が `__identity` は従来 oneshot、それ以外は server-channel registry へ routing し raw `UnisonStream` を渡す。**未登録は従来どおり drop+warn（無回帰）**。
- **`quic.rs` / `client.rs`**: `ProtocolClient` / `QuicClient` に `register_server_channel` + registry。
- **既存 `UnisonChannel` は不変**（best-effort event drop はそのまま据え置き＝無回帰）。

## テスト

- `test_server_initiated_reliable_ordered_delivery` — 200件の server→client push が**全件・同順で到達**（reliability + ordering 実証、QUIC e2e）
- `test_server_initiated_unregistered_channel_no_regression` — 未登録 channel は drop しても接続維持
- `test_open_server_stream_on_client_ctx_is_misuse_error` — client ctx の誤用は error
- `cargo clippy --lib --workspace -D warnings` クリーン / `cargo test --workspace` 全 pass

## 剃刀（意図的に足さないもの）

- `get_connection_by_principal` 等の lookup table / relay 専用 API は substrate に置かない（利用側 = hub が `wld_id→ctx` map を持つ）
- aggregate（多重相関）と既存 `UnisonChannel` の global reliable 化は consumer が出るまで保留
- `build_identity()` の `from=server` honor は direction source 整備待ちで二次的（本 PR 未対応、schema↔runtime 齟齬は残置）

## 既知の制約

- client 受信経路は raw QUIC 専用（`client_accept_bi_loop` が `quinn::Connection`）のため、WebTransport client は server-initiated channel を受けられない（native client は可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)