### PR TITLE
docs(alpn)+test: ALPN は後方互換でない訂正 + enforcement 回帰テスト

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,15 @@
 
 > Apple `NWProtocolQUIC` との interop のため raw QUIC に ALPN を追加し
 > (RFC 9001 §8.1 — QUIC は ALPN 必須)、Swift native client SDK (`clients/swift`)
-> を新設。SemVer minor (= additive)。raw QUIC は server/client 両端が同 label を
-> negotiate するため後方互換。
+> を新設。SemVer minor (= additive)。
+>
+> ⚠️ **互換性の訂正**（当初の「後方互換」記述は誤り）: ALPN を設定した server は
+> ALPN を出さない**旧 raw QUIC client を `no_application_protocol` で拒否する**
+> (QUIC は ALPN 必須で、rustls/quinn は plain TLS と違い handshake 時に enforce
+> する — empty-ALPN client での実測で確認)。raw QUIC client（Rust / Ruby FFI）は
+> **club-unison 1.3.0+ にビルドし直して `"unison"` ALPN を送る必要がある**。
+> WebTransport（TS）は HTTP/3 の `"h3"` 別 ingress なので無影響。詳細は
+> `design/quic-runtime.md` の ALPN 節。
 
 ### Added
 

--- a/crates/unison-protocol/tests/test_alpn_enforcement.rs
+++ b/crates/unison-protocol/tests/test_alpn_enforcement.rs
@@ -1,0 +1,107 @@
+//! ALPN enforcement の回帰テスト (v1.3.0+)。
+//!
+//! QUIC は RFC 9001 §8.1 で ALPN を必須とし、rustls/quinn は plain TLS と違い
+//! handshake 時に enforce する。`network::UNISON_ALPN` (= `"unison"`) を設定した
+//! server に対し:
+//! - **ALPN を送る client** は接続できる（positive）。
+//! - **ALPN を送らない旧 client** は `no_application_protocol` で拒否される（negative）。
+//!
+//! この非対称が「v1.3.0 は raw QUIC client にとって breaking（後方互換ではない）」の
+//! 根拠であり、Ruby gem 等の旧 client は再ビルドが必要。詳細は
+//! `design/quic-runtime.md` の ALPN 節。
+//!
+//! handshake のみで完結するため軽量・決定論的。CI でも走らせて契約を守る
+//! (= 他の Medium QUIC test と違い `#[ignore]` を付けない)。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use quinn::{ClientConfig, Endpoint};
+use rustls::ClientConfig as RustlsClientConfig;
+use tokio::time::timeout;
+
+use unison::network::trust::TrustAnchors;
+use unison::network::{ProtocolServer, QuicServer};
+
+/// dev_localhost cert（= ALPN "unison" が自動設定される）の server を spawn し、
+/// 接続用アドレスを返す。
+async fn spawn_server() -> String {
+    let server = Arc::new(ProtocolServer::with_identity("alpn-test", "1.0.0", "test"));
+    let mut quic = QuicServer::new(Arc::clone(&server));
+    quic.bind("[::1]:0").await.expect("bind");
+    let local = quic.local_addr().expect("local_addr");
+    let addr = format!("[{}]:{}", local.ip(), local.port());
+    tokio::spawn(async move {
+        let _ = quic.start().await;
+    });
+    addr
+}
+
+/// 指定 ALPN で client endpoint を作り、server へ接続を試みる。
+async fn try_connect(addr: &str, alpn: &[&str]) -> Result<(), String> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mut rustls_cfg: RustlsClientConfig =
+        (*TrustAnchors::SkipVerification.build_client_config().unwrap()).clone();
+    // テストしたい ALPN で上書き（空配列 = 旧 client を再現）。
+    rustls_cfg.alpn_protocols = alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
+
+    let crypto = quinn::crypto::rustls::QuicClientConfig::try_from(rustls_cfg)
+        .map_err(|e| format!("client crypto config: {e}"))?;
+    let client_config = ClientConfig::new(Arc::new(crypto));
+
+    let mut endpoint = Endpoint::client("[::]:0".parse().unwrap()).map_err(|e| e.to_string())?;
+    endpoint.set_default_client_config(client_config);
+
+    let sockaddr: std::net::SocketAddr = addr.parse().map_err(|e: std::net::AddrParseError| e.to_string())?;
+    let result = timeout(Duration::from_secs(5), async {
+        endpoint
+            .connect(sockaddr, "localhost")
+            .map_err(|e| e.to_string())?
+            .await
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|_| "connect timeout".to_string())?;
+
+    result.map(|_conn| ())
+}
+
+#[tokio::test]
+async fn unison_alpn_client_connects() {
+    let addr = spawn_server().await;
+    let result = try_connect(&addr, &["unison"]).await;
+    assert!(
+        result.is_ok(),
+        "\"unison\" ALPN を送る client は接続できるべき: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn empty_alpn_client_is_rejected() {
+    let addr = spawn_server().await;
+    let result = try_connect(&addr, &[]).await;
+    // QUIC は ALPN 必須 → ALPN 無しの旧 client は handshake で弾かれる。
+    assert!(
+        result.is_err(),
+        "ALPN を送らない旧 client は拒否されるべき (後方互換ではない)"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("protocol") || err.contains("handshake") || err.contains("120"),
+        "no_application_protocol 由来の handshake 失敗を期待: {err}"
+    );
+}
+
+#[tokio::test]
+async fn mismatched_alpn_client_is_rejected() {
+    let addr = spawn_server().await;
+    // server は "unison" のみ。別 label を出す client は negotiate 失敗。
+    let result = try_connect(&addr, &["h3"]).await;
+    assert!(
+        result.is_err(),
+        "server の ALPN と一致しない client は拒否されるべき"
+    );
+}

--- a/crates/unison-protocol/tests/test_alpn_enforcement.rs
+++ b/crates/unison-protocol/tests/test_alpn_enforcement.rs
@@ -43,8 +43,10 @@ async fn try_connect(addr: &str, alpn: &[&str]) -> Result<(), String> {
         .install_default()
         .ok();
 
-    let mut rustls_cfg: RustlsClientConfig =
-        (*TrustAnchors::SkipVerification.build_client_config().unwrap()).clone();
+    let mut rustls_cfg: RustlsClientConfig = (*TrustAnchors::SkipVerification
+        .build_client_config()
+        .unwrap())
+    .clone();
     // テストしたい ALPN で上書き（空配列 = 旧 client を再現）。
     rustls_cfg.alpn_protocols = alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
 
@@ -55,7 +57,9 @@ async fn try_connect(addr: &str, alpn: &[&str]) -> Result<(), String> {
     let mut endpoint = Endpoint::client("[::]:0".parse().unwrap()).map_err(|e| e.to_string())?;
     endpoint.set_default_client_config(client_config);
 
-    let sockaddr: std::net::SocketAddr = addr.parse().map_err(|e: std::net::AddrParseError| e.to_string())?;
+    let sockaddr: std::net::SocketAddr = addr
+        .parse()
+        .map_err(|e: std::net::AddrParseError| e.to_string())?;
     let result = timeout(Duration::from_secs(5), async {
         endpoint
             .connect(sockaddr, "localhost")

--- a/design/quic-runtime.md
+++ b/design/quic-runtime.md
@@ -17,9 +17,21 @@ QUIC は仕様（RFC 9001 §8.1）で ALPN を必須とする。raw QUIC の ser
 （`quic.rs`）と client（`trust.rs`）は SSOT である `network::UNISON_ALPN`
 （= `"unison"`）を negotiate する。空 ALPN は仕様逸脱であり、Apple
 `NWProtocolQUIC` 等の厳格実装（Swift client）と interop できないため v1.3.0 で
-明示設定した。server / client が同 label で合意するため Rust↔Rust / Ruby（FFI）は
-後方互換。WebTransport 経路は HTTP/3 上のため ALPN は `"h3"` 固定（`wtransport`
-依存が内部設定）で、本 const は適用されない（別 ingress）。
+明示設定した。
+
+> ⚠️ **互換性（重要）**: ALPN を設定した server は、ALPN を送らない**旧 client を
+> `no_application_protocol` で拒否する**。QUIC は ALPN 必須なので、rustls/quinn は
+> plain TLS（client が ALPN を出さなければ enforce しない）と違い handshake 時に
+> **enforce する**（empty-ALPN client での実測で確認済み）。したがって v1.3.0 は
+> raw QUIC client にとって **breaking** で、**後方互換ではない**:
+> - **Rust client / Swift client**: `"unison"` を送るため OK。
+> - **Ruby client（FFI）**: gem が pin する `club-unison` を **1.3.0+ に上げて
+>   ビルドし直す必要がある**（旧 lock の 1.0.x は empty ALPN → 拒否される）。
+> - **WebTransport（TS）**: HTTP/3 の `"h3"` 別 ingress なので**無影響**。
+>
+> WebTransport 経路は HTTP/3 上のため ALPN は `"h3"` 固定（`wtransport` 依存が内部
+> 設定）で、本 const は適用されない（別 ingress）。回帰テスト:
+> `crates/unison-protocol/tests/test_alpn_enforcement.rs`。
 
 全体のアーキテクチャ層における位置付け:
 


### PR DESCRIPTION
## 概要

#74(raw QUIC ALPN `"unison"`)を CHANGELOG / docs で「**後方互換**」と記載していたが、**誤り**だった。実測により、ALPN を設定した server は **ALPN を送らない旧 client を `no_application_protocol` で拒否する**ことを確認(QUIC は RFC 9001 §8.1 で ALPN 必須、rustls/quinn は plain TLS と違い handshake 時に enforce する)。

その訂正と、契約を固める回帰テストを追加。

## なぜ気づいたか

「Ruby/TS は 1.3.0 server にそのまま繋がるか?」の確認で、empty-ALPN client を立てて 1.3.0 server に接続する negative test を実施 → `error 120: peer doesn't support any known protocol` で**拒否**された。plain TLS の rustls は client が ALPN を出さなければ enforce しないが、**QUIC モードでは ALPN mandatory** で挙動が逆だった。

## 変更

- **CHANGELOG [1.3.0]**: 「後方互換」記述を互換性訂正に差し替え
  - raw QUIC client(Rust / Ruby FFI)は **club-unison 1.3.0+ に再ビルドして `"unison"` ALPN を送る必要**
  - Rust / Swift client は OK(`"unison"` を送る)
  - WebTransport(TS)は HTTP/3 `"h3"` 別 ingress で**無影響**
- **design/quic-runtime.md**: ALPN 節の「Ruby(FFI)は後方互換」の誤記を訂正、breaking を明記
- **`test_alpn_enforcement.rs`(新規・非 `#[ignore]`)**: 回帰として CI で常時実行
  - `unison_alpn_client_connects`(positive)
  - `empty_alpn_client_is_rejected`(negative = 後方互換でない証明)
  - `mismatched_alpn_client_is_rejected`(`"h3"` client も拒否)

## 検証

- [x] `cargo test --test test_alpn_enforcement` 3/3 pass(0.01s、handshake のみで軽量)
- [x] `cargo clippy --test test_alpn_enforcement -- -D warnings` clean

## follow-up(別 PR)

- **Ruby gem 再ビルド + 再公開**: `clients/ruby/Cargo.lock` が `club-unison 1.0.0`(empty ALPN)を pin したままなので、`cargo update -p club-unison` → 1.5.0 → gem 0.1.1 publish が必要(= 現状の gem 0.1.0 は 1.3.0+ server に繋がらない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)