### PR TITLE
feat(network): connect_race — Happy Eyeballs v2 dialer (engine + direct adapter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@
 
 ## [Unreleased]
 
+### Added
+
+- **connect_race — Happy Eyeballs v2 staggered-race dialer**（`network::dial` / `network::client` /
+  `network::quic`、ADR-020 §S6）: 複数の direct 候補へ *逐次フォールバック* でなく
+  **1 本の時間差レース**で接続し、最初に握手完了した経路を採用・残りを cancel する dialer。
+  per-endpoint timeout の「短すぎ＝良経路誤棄／長すぎ＝数秒待ち」ジレンマを、有界な stagger
+  だけで構造的に解消する（死経路コスト = stagger 1 tick、「全滅」判定は不要）。
+  - `network::dial::race` / `rank`: network 非依存の generic engine。実 I/O は `attempt` closure に
+    閉じ、並行タイミングの状態機械を**仮想時間**（`start_paused = true`）で決定論的にテスト
+    （unit 10 件）。eager relay arm（握手済 relay を `relay_handicap` まで hold し direct に勝機を
+    与える → direct 失敗時の failover +0 RTT）を doctrine default に持つ。
+  - `ProtocolClient::connect_race(addrs, server_name, cfg)` / `QuicClient::connect_race`:
+    1 個の client Endpoint から IPv6 GUA 候補を staggered race。成功後は `connect` と同じ状態
+    （identity / イベント / datagram）で使える。IPv4 は §D3 で deferred のため warn して skip、
+    relay fallback は次段（`Transport` 抽象）。
+  - `RaceCfg { stagger, relay_handicap, overall_deadline }`: レースのチューニング
+    （default = eager relay arm）。
+
+  設計 SSOT: [`design/happy-eyeballs-dial.md`](design/happy-eyeballs-dial.md)。
+  SemVer minor（additive・opt-in、既存 `connect` API は不変）。
+
 ## [1.5.0] - 2026-06-28 — server-initiated reliable stream (`ServerToClient` を起こす)
 
 > server 起点で connected client へ **reliable・同順** な stream を開く primitive を追加。

--- a/crates/unison-protocol/Cargo.toml
+++ b/crates/unison-protocol/Cargo.toml
@@ -76,6 +76,8 @@ buffa-build.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 tokio-test.workspace = true
+# dial.rs のレーステスト用に仮想時間（start_paused）を有効化。
+tokio = { workspace = true, features = ["test-util"] }
 criterion.workspace = true
 hdrhistogram.workspace = true
 

--- a/crates/unison-protocol/src/network/client.rs
+++ b/crates/unison-protocol/src/network/client.rs
@@ -334,6 +334,13 @@ impl ProtocolClient {
             .await
             .map_err(|e| NetworkError::Connection(e.to_string()))?;
 
+        self.after_connect().await
+    }
+
+    /// transport 確立後の共通後処理（datagram dispatcher reset / Connected event fire /
+    /// drop detection task / Identity handshake）。[`connect`](Self::connect) /
+    /// [`connect_race`](Self::connect_race) が共有する。
+    async fn after_connect(&self) -> Result<(), NetworkError> {
         // reconnect 対策: 古い connection に bind された datagram dispatcher を破棄する。
         // dispatcher は spawn 時の connection を握ったままなので、 これを clear しないと
         // reconnect 後の open_datagram_channel が死んだ旧 connection の dispatcher を
@@ -374,6 +381,24 @@ impl ProtocolClient {
         }
 
         Ok(())
+    }
+
+    /// 複数の direct 候補へ Happy Eyeballs v2 の staggered race で接続する（ADR-020 §S6）。
+    ///
+    /// direct-first-cut: IPv6 GUA のみ race（IPv4 は §D3 deferred で skip、relay fallback は
+    /// 次段）。`server_name` は全候補共通（= 同一 world の cert 名前検証に使う）。成功後は
+    /// [`connect`](Self::connect) と同じ状態（identity/イベント/datagram）で使える。
+    pub async fn connect_race(
+        &self,
+        addrs: Vec<SocketAddr>,
+        server_name: &str,
+        cfg: super::dial::RaceCfg,
+    ) -> Result<(), NetworkError> {
+        self.transport
+            .connect_race(addrs, server_name, cfg)
+            .await
+            .map_err(|e| NetworkError::Connection(e.to_string()))?;
+        self.after_connect().await
     }
 
     /// Unisonサーバーへ接続し、 接続直後に credential を1回提示して認証する

--- a/crates/unison-protocol/src/network/dial.rs
+++ b/crates/unison-protocol/src/network/dial.rs
@@ -1,0 +1,476 @@
+//! `dial` — Happy Eyeballs v2 (RFC 8305) 型の staggered-race dialer。
+//!
+//! chronista-hub ADR-020 §S6 の consume 側。到達性 ladder（D3 `direct → relay`）を
+//! *逐次フォールバック* でなく **1 本の時間差レース** に畳む。direct（別アドレス）と
+//! relay（hub 経由の別到達機構）を「優先度と stagger だけ違う候補」に均し、最初に握手
+//! 完了した経路を採用、残りは cancel する。「全滅」を誰も判定しない —— 遅延ノブは有界な
+//! stagger だけで、per-endpoint timeout の「短すぎ＝良経路誤棄／長すぎ＝数秒待ち」
+//! ジレンマが構造的に消える。
+//!
+//! # 設計: engine と I/O の分離（§S6 の data/calc/action）
+//!
+//! [`race`] は **network 非依存の generic engine**。実際の握手（quinn connect /
+//! relay channel open）は呼び出し側が渡す `attempt` closure に閉じる。これにより
+//! 並行タイミングの状態機械を仮想時間で決定論的にテストでき（本ファイル末尾）、
+//! 実 I/O は薄い adapter に寄る。[`rank`] は副作用ゼロの候補ランキング。
+//!
+//! # eager relay（doctrine default、ADR-020 §S6 user 確定 2026-07-07）
+//!
+//! relay 候補があれば **t=0 で先行 arm**（既存 hub connection 上の open ≈1 RTT）し、
+//! 握手済でも `relay_handicap` 経過まで **採用を hold** する。direct が hold 中に完了
+//! すれば direct 採用（relay は drop で tear down）。direct が全滅 or handicap 経過なら
+//! relay を即採用 —— relay は既に握手済なので failover は **+0 RTT**。
+//!
+//! # 勝者以外の tear down 契約（境界①）
+//!
+//! engine は敗者を **future の drop** で cancel する。`Winner<T>` / 進行中 attempt が
+//! 保持する transport `T` は、**Drop 時に relay stream を確実に close** する実装で
+//! なければならない（hub は dialer の `open` で `wld_id→ctx` の transient forwarding
+//! state を持つ ── `unison_server.rs`。放置すると握手ドロップ検知まで残り、D1 の
+//! 「durable 0」を一瞬でも欠く）。direct（quinn::Connection）は drop で UDP が閉じる。
+//!
+//! # 実 adapter の配線（次段: `ProtocolClient::connect_race` として）
+//!
+//! ```ignore
+//! enum Transport { Direct(quinn::Connection), Relay(UnisonChannel) }
+//! impl Drop for Transport { /* Relay は close して hub transient を即消す */ }
+//!
+//! // direct: 共有 client Endpoint から 1 発 connect（quic.rs:390 の core を切り出し）。
+//! async fn direct_attempt(ep: &quinn::Endpoint, addr: SocketAddr, sni: &str)
+//!     -> AttemptOutcome<Transport>
+//! {
+//!     let t0 = Instant::now();
+//!     match ep.connect(addr, sni) {
+//!         Ok(conn) => match conn.await {
+//!             Ok(c)  => AttemptOutcome::Connected {
+//!                 transport: Transport::Direct(c), via: Via::Direct(addr), rtt: t0.elapsed() },
+//!             Err(_) => AttemptOutcome::Failed { via: Via::Direct(addr) },
+//!         },
+//!         Err(_) => AttemptOutcome::Failed { via: Via::Direct(addr) },
+//!     }
+//! }
+//!
+//! // relay: Discover で確立済の hub ProtocolClient を再利用。arm = open + declare（≈1 RTT）。
+//! async fn relay_attempt(hub: &ProtocolClient, to: WldId) -> AttemptOutcome<Transport> {
+//!     let t0 = Instant::now();
+//!     match hub.open_channel("relay").await {                       // client.rs:175
+//!         Ok(ch) => match ch.request::<_, serde_json::Value>("open", &serde_json::json!({"to": to})).await {
+//!             Ok(_)  => AttemptOutcome::Connected {
+//!                 transport: Transport::Relay(ch), via: Via::Relay(to), rtt: t0.elapsed() },
+//!             Err(_) => AttemptOutcome::Failed { via: Via::Relay(to) },
+//!         },
+//!         Err(_) => AttemptOutcome::Failed { via: Via::Relay(to) },
+//!     }
+//! }
+//! ```
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use futures_util::stream::FuturesUnordered;
+use tokio::time::{Instant, sleep};
+
+/// location 独立の home-World 番地（ADR-020 D2）。relay 中継の宛先 routing key。
+pub type WldId = String;
+
+/// 到達候補。[`rank`] が優先度順に並べ、[`race`] が stagger を付けて arm する。
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Candidate {
+    /// direct: IPv6 GUA /（将来）IPv4 / tailnet。到達手段は「その addr へ QUIC 握手」だけ。
+    /// 全滅しても hub は無関係（D3-a、hub data 不在）。
+    Direct(SocketAddr),
+    /// relay = universal floor（D3-b）。hub 経由の *別到達機構*。arm = hub conn 上に
+    /// `relay` channel を開き `open{to}` 宣言。負け時は hub の transient state を tear down。
+    Relay(WldId),
+}
+
+impl Candidate {
+    /// direct 候補か（partition / arm スケジュールの分岐）。
+    pub fn is_direct(&self) -> bool {
+        matches!(self, Candidate::Direct(_))
+    }
+
+    /// この候補が勝った場合の観測種別（transport を剥がした [`Via`]）。adapter が
+    /// `AttemptOutcome` を組むときの mapping にも使う。
+    pub fn via(&self) -> Via {
+        match self {
+            Candidate::Direct(a) => Via::Direct(*a),
+            Candidate::Relay(w) => Via::Relay(w.clone()),
+        }
+    }
+}
+
+/// レースのチューニング。doctrine default = **eager relay arm**（ADR-020 §S6）。
+#[derive(Clone, Debug)]
+pub struct RaceCfg {
+    /// direct 候補間の stagger（RFC 8305 Connection Attempt Delay）。QUIC 1-RTT 基準で
+    /// 250ms は緩め。RFC 下限 100–150ms まで詰め可（win-cache の実測 RTT で適応化）。
+    pub stagger: Duration,
+    /// eager relay の adoption gate。握手済 relay をここまで hold し、in-flight direct に
+    /// 勝機を与える。0 なら relay を待たせず即採用、大きいほど direct 優先が強い。
+    pub relay_handicap: Duration,
+    /// 全体の hard deadline。越えたら握手済 relay を拾うか [`RaceError::Deadline`]。
+    pub overall_deadline: Duration,
+}
+
+impl Default for RaceCfg {
+    fn default() -> Self {
+        Self {
+            stagger: Duration::from_millis(250),
+            relay_handicap: Duration::from_millis(500),
+            overall_deadline: Duration::from_secs(10),
+        }
+    }
+}
+
+/// 採用された経路。`transport` は勝った I/O ハンドル、`via`/`rtt` は win-cache・庭師供給用。
+#[derive(Debug)]
+pub struct Winner<T> {
+    pub transport: T,
+    pub via: Via,
+    /// 勝者候補の握手 RTT（win-cache → ADR-020 Open point #1 庭師の "actual reachability"）。
+    pub rtt: Duration,
+}
+
+/// 勝った経路の種別（`Candidate` から transport を剥がした観測値）。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Via {
+    Direct(SocketAddr),
+    Relay(WldId),
+}
+
+/// 1 候補の握手結果。`attempt` closure が返す。
+#[derive(Debug)]
+pub enum AttemptOutcome<T> {
+    Connected { transport: T, via: Via, rtt: Duration },
+    Failed { via: Via },
+}
+
+/// レースの失敗。
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RaceError {
+    #[error("候補が空")]
+    NoCandidates,
+    /// 全候補が握手失敗（黒穴/拒否）。deadline を待たず即返す。
+    #[error("全候補が握手失敗")]
+    AllFailed,
+    /// deadline までにどの候補も握手完了しなかった（in-flight のまま時間切れ）。
+    #[error("deadline 超過")]
+    Deadline,
+}
+
+/// hub の opaque 順序付き候補（D2）に *消費側で* 意味を与える純関数（副作用ゼロ）。
+///
+/// 規則:
+/// - 同一 prefix（/64,/48）共有の direct GUA = 同一サイト → 先頭（低 RTT 期待）〔TODO〕
+/// - IPv4 導入時は family interleave（v6,v4,…）で片 family 黒穴の頭独占を防ぐ〔TODO〕
+/// - relay は最劣後（末尾）
+///
+/// 現状は IPv6 GUA のみ運用（ADR-020 §D3、IPv4 deferred）ゆえ direct は順序保持で足りる。
+pub fn rank(candidates: Vec<Candidate>, my_addrs: &[IpAddr]) -> Vec<Candidate> {
+    let (direct, relay): (Vec<_>, Vec<_>) = candidates.into_iter().partition(Candidate::is_direct);
+    // TODO(§S6): direct.sort_by_key(|c| prefix_distance(c, my_addrs))  // 同一サイト優先
+    // TODO(§S6): family interleave（IPv4 導入後）
+    let _ = my_addrs;
+    direct.into_iter().chain(relay).collect()
+}
+
+/// 順序付き候補を stagger 付きで並行 arm し、最初に握手完了した経路を採用する（HEv2）。
+///
+/// `attempt` は 1 候補の握手を行う closure。全呼び出しが同一の future 型を返すため
+/// boxing 不要（`FuturesUnordered<Fut>`）。engine は `Candidate` の direct/relay 区別と
+/// タイマだけを見て、I/O は一切知らない。
+pub async fn race<T, F, Fut>(
+    candidates: Vec<Candidate>,
+    my_addrs: &[IpAddr],
+    cfg: RaceCfg,
+    mut attempt: F,
+) -> Result<Winner<T>, RaceError>
+where
+    F: FnMut(Candidate) -> Fut,
+    Fut: Future<Output = AttemptOutcome<T>>,
+{
+    let ranked = rank(candidates, my_addrs);
+    if ranked.is_empty() {
+        return Err(RaceError::NoCandidates);
+    }
+
+    let (direct_v, relays): (Vec<_>, Vec<_>) = ranked.into_iter().partition(Candidate::is_direct);
+    let mut directs: VecDeque<Candidate> = direct_v.into();
+    let had_direct = !directs.is_empty();
+
+    let mut inflight = FuturesUnordered::new();
+    let mut outstanding = 0usize;
+
+    // eager: relay(s) を t=0 で先行 arm。
+    for r in relays {
+        inflight.push(attempt(r));
+        outstanding += 1;
+    }
+    // 最初の direct を arm。
+    if let Some(d) = directs.pop_front() {
+        inflight.push(attempt(d));
+        outstanding += 1;
+    }
+
+    // direct 候補が皆無なら relay を hold しない（勝機を与える相手が居ない）。
+    let mut gate_open = !had_direct;
+    let mut relay_ready: Option<Winner<T>> = None;
+
+    let stagger = sleep(cfg.stagger);
+    tokio::pin!(stagger);
+    let gate = sleep(cfg.relay_handicap);
+    tokio::pin!(gate);
+    let deadline = sleep(cfg.overall_deadline);
+    tokio::pin!(deadline);
+
+    loop {
+        // 終了判定: 進行中ゼロ かつ arm 待ち direct なし。
+        //   → 握手済 relay を hold していれば即採用（handicap を待たない）、無ければ全滅。
+        if outstanding == 0 && directs.is_empty() {
+            return relay_ready.ok_or(RaceError::AllFailed);
+        }
+
+        tokio::select! {
+            // (1) stagger tick → 次の direct を並行 arm（前が未完でも構わず）。
+            _ = &mut stagger => {
+                if let Some(d) = directs.pop_front() {
+                    inflight.push(attempt(d));
+                    outstanding += 1;
+                }
+                stagger.as_mut().reset(Instant::now() + cfg.stagger);
+            }
+
+            // (2) relay adoption gate。握手済 relay があれば即採用（failover +0 RTT）。
+            _ = &mut gate, if !gate_open => {
+                gate_open = true;
+                if let Some(w) = relay_ready.take() {
+                    return Ok(w); // 敗者は inflight drop で cancel（tear down は T::drop）
+                }
+            }
+
+            // (3) いずれかの握手が resolve。
+            Some(outcome) = inflight.next() => {
+                outstanding -= 1;
+                match outcome {
+                    AttemptOutcome::Connected { transport, via, rtt } => {
+                        let winner = Winner { transport, via: via.clone(), rtt };
+                        match via {
+                            // direct は即採用（held relay があっても direct 優先）。
+                            Via::Direct(_) => return Ok(winner),
+                            Via::Relay(_) => {
+                                if gate_open {
+                                    return Ok(winner);
+                                }
+                                relay_ready = Some(winner); // eager: 握手済を hold
+                            }
+                        }
+                    }
+                    // 黒穴/拒否は待たない。direct 失敗なら次 direct を *即* arm（RFC 8305）。
+                    AttemptOutcome::Failed { via } => {
+                        if matches!(via, Via::Direct(_))
+                            && let Some(d) = directs.pop_front()
+                        {
+                            inflight.push(attempt(d));
+                            outstanding += 1;
+                        }
+                    }
+                }
+            }
+
+            // (4) hard deadline。in-flight のまま時間切れ → 握手済 relay を拾うか Deadline。
+            _ = &mut deadline => {
+                return relay_ready.take().ok_or(RaceError::Deadline);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! 決定論テスト（仮想時間 = `#[tokio::test(start_paused = true)]`）。
+    //! fake `attempt` が scripted な握手 latency を `sleep` で演じる。tokio が全タスク
+    //! idle 時に仮想時計を次のタイマまで自動前進させるため、実時間 0 で確定的に回る。
+
+    use super::*;
+    use std::collections::HashMap;
+    use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+    use std::time::Duration;
+    use tokio::time::{Instant, sleep};
+
+    fn d(port: u16) -> Candidate {
+        Candidate::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), port))
+    }
+    fn r(id: &str) -> Candidate {
+        Candidate::Relay(id.to_string())
+    }
+
+    #[derive(Clone)]
+    enum Script {
+        /// `delay` 後に握手成功。
+        Ok(Duration),
+        /// `delay` 後に握手失敗（黒穴は大きい delay で表す）。
+        Fail(Duration),
+    }
+
+    /// script から uniform な future 型を返す attempt closure を作る。`T = Candidate`
+    /// （どの候補が勝ったかを transport で assert する）。
+    fn attempter(
+        script: HashMap<Candidate, Script>,
+    ) -> impl FnMut(Candidate) -> std::pin::Pin<Box<dyn Future<Output = AttemptOutcome<Candidate>>>>
+    {
+        move |c: Candidate| {
+            let s = script.get(&c).cloned();
+            Box::pin(async move {
+                let via = c.via();
+                match s {
+                    Some(Script::Ok(delay)) => {
+                        sleep(delay).await;
+                        AttemptOutcome::Connected { transport: c, via, rtt: delay }
+                    }
+                    Some(Script::Fail(delay)) => {
+                        sleep(delay).await;
+                        AttemptOutcome::Failed { via }
+                    }
+                    None => AttemptOutcome::Failed { via }, // 未 script = 即失敗
+                }
+            })
+        }
+    }
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    /// 経過（仮想）時間が `expect` ± 40ms に入るか。
+    fn near(elapsed: Duration, expect: u64) -> bool {
+        let e = elapsed.as_millis() as i64;
+        (e - expect as i64).abs() <= 40
+    }
+
+    // ── pure ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn rank_puts_relay_last_and_keeps_direct_order() {
+        let out = rank(vec![r("h"), d(1), d(2)], &[]);
+        assert_eq!(out, vec![d(1), d(2), r("h")]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_is_no_candidates() {
+        let res = race(vec![], &[], RaceCfg::default(), attempter(HashMap::new())).await;
+        assert_eq!(res.unwrap_err(), RaceError::NoCandidates);
+    }
+
+    // ── happy path ────────────────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn first_direct_wins_without_racing() {
+        let script = HashMap::from([(d(1), Script::Ok(ms(50)))]);
+        let t0 = Instant::now();
+        let w = race(vec![d(1), d(2)], &[], RaceCfg::default(), attempter(script))
+            .await
+            .unwrap();
+        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1)));
+        // 50ms < stagger 250ms → d(2) は arm される前に決着。
+        assert!(near(t0.elapsed(), 50), "elapsed = {:?}", t0.elapsed());
+    }
+
+    // ── dead direct のコスト = stagger 1 tick ────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn blackhole_direct_costs_one_stagger_tick() {
+        // d(1) は黒穴（deadline 手前まで無応答）、d(2) が生きている。
+        let script = HashMap::from([(d(1), Script::Fail(ms(9_000))), (d(2), Script::Ok(ms(80)))]);
+        let t0 = Instant::now();
+        let w = race(vec![d(1), d(2)], &[], RaceCfg::default(), attempter(script))
+            .await
+            .unwrap();
+        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 2)));
+        // d(2) は stagger 250ms で arm → 80ms 後 = 330ms に完了。黒穴 timeout を待たない。
+        assert!(near(t0.elapsed(), 330), "elapsed = {:?}", t0.elapsed());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fast_fail_direct_chains_next_immediately() {
+        // d(1) が即失敗 → stagger を待たず d(2) を即 arm。
+        let script = HashMap::from([(d(1), Script::Fail(ms(10))), (d(2), Script::Ok(ms(40)))]);
+        let t0 = Instant::now();
+        let w = race(vec![d(1), d(2)], &[], RaceCfg::default(), attempter(script))
+            .await
+            .unwrap();
+        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 2)));
+        assert!(near(t0.elapsed(), 50), "elapsed = {:?} (10 fail + 40 ok)", t0.elapsed());
+    }
+
+    // ── eager relay ──────────────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn eager_relay_adopts_at_gate_when_directs_blackhole() {
+        // direct 両方黒穴、relay は 30ms で握手済 → gate 500ms で採用（+0 RTT）。
+        let script = HashMap::from([
+            (d(1), Script::Fail(ms(9_000))),
+            (d(2), Script::Fail(ms(9_000))),
+            (r("hub"), Script::Ok(ms(30))),
+        ]);
+        let t0 = Instant::now();
+        let w = race(vec![d(1), d(2), r("hub")], &[], RaceCfg::default(), attempter(script))
+            .await
+            .unwrap();
+        assert_eq!(w.via, Via::Relay("hub".into()));
+        assert_eq!(w.rtt, ms(30)); // relay 握手は 30ms（gate は adoption を遅らせるだけ）
+        assert!(near(t0.elapsed(), 500), "elapsed = {:?} (gate)", t0.elapsed());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn eager_relay_adopts_early_when_directs_fail_fast() {
+        // direct が確定的に即失敗 → handicap 全部を待たず relay を早期採用。
+        let script = HashMap::from([
+            (d(1), Script::Fail(ms(10))),
+            (d(2), Script::Fail(ms(10))),
+            (r("hub"), Script::Ok(ms(30))),
+        ]);
+        let t0 = Instant::now();
+        let w = race(vec![d(1), d(2), r("hub")], &[], RaceCfg::default(), attempter(script))
+            .await
+            .unwrap();
+        assert_eq!(w.via, Via::Relay("hub".into()));
+        // d(1)@10 fail→d(2) arm@10→fail@20、relay@30 完了で全 direct 決着済 → 30ms 採用。
+        assert!(near(t0.elapsed(), 30), "elapsed = {:?} (early)", t0.elapsed());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn direct_beats_already_connected_relay() {
+        // relay は 20ms で握手済（hold）、direct は 100ms で完了 → direct 優先。
+        let script =
+            HashMap::from([(r("hub"), Script::Ok(ms(20))), (d(1), Script::Ok(ms(100)))]);
+        let t0 = Instant::now();
+        let w = race(vec![d(1), r("hub")], &[], RaceCfg::default(), attempter(script))
+            .await
+            .unwrap();
+        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1)));
+        assert!(near(t0.elapsed(), 100), "elapsed = {:?}", t0.elapsed());
+    }
+
+    // ── 失敗系 ────────────────────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn all_direct_fail_no_relay_is_all_failed() {
+        let script = HashMap::from([(d(1), Script::Fail(ms(10)))]);
+        let res = race(vec![d(1)], &[], RaceCfg::default(), attempter(script)).await;
+        assert_eq!(res.unwrap_err(), RaceError::AllFailed);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn blackhole_without_relay_hits_deadline() {
+        let script = HashMap::from([(d(1), Script::Fail(ms(9_000)))]); // deadline より長い
+        let cfg = RaceCfg { overall_deadline: ms(1_000), ..Default::default() };
+        let t0 = Instant::now();
+        let res = race(vec![d(1)], &[], cfg, attempter(script)).await;
+        assert_eq!(res.unwrap_err(), RaceError::Deadline);
+        assert!(near(t0.elapsed(), 1_000), "elapsed = {:?}", t0.elapsed());
+    }
+}

--- a/crates/unison-protocol/src/network/dial.rs
+++ b/crates/unison-protocol/src/network/dial.rs
@@ -145,8 +145,14 @@ pub enum Via {
 /// 1 候補の握手結果。`attempt` closure が返す。
 #[derive(Debug)]
 pub enum AttemptOutcome<T> {
-    Connected { transport: T, via: Via, rtt: Duration },
-    Failed { via: Via },
+    Connected {
+        transport: T,
+        via: Via,
+        rtt: Duration,
+    },
+    Failed {
+        via: Via,
+    },
 }
 
 /// レースの失敗。
@@ -329,7 +335,11 @@ mod tests {
                 match s {
                     Some(Script::Ok(delay)) => {
                         sleep(delay).await;
-                        AttemptOutcome::Connected { transport: c, via, rtt: delay }
+                        AttemptOutcome::Connected {
+                            transport: c,
+                            via,
+                            rtt: delay,
+                        }
                     }
                     Some(Script::Fail(delay)) => {
                         sleep(delay).await;
@@ -374,7 +384,10 @@ mod tests {
         let w = race(vec![d(1), d(2)], &[], RaceCfg::default(), attempter(script))
             .await
             .unwrap();
-        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1)));
+        assert_eq!(
+            w.via,
+            Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1))
+        );
         // 50ms < stagger 250ms → d(2) は arm される前に決着。
         assert!(near(t0.elapsed(), 50), "elapsed = {:?}", t0.elapsed());
     }
@@ -389,7 +402,10 @@ mod tests {
         let w = race(vec![d(1), d(2)], &[], RaceCfg::default(), attempter(script))
             .await
             .unwrap();
-        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 2)));
+        assert_eq!(
+            w.via,
+            Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 2))
+        );
         // d(2) は stagger 250ms で arm → 80ms 後 = 330ms に完了。黒穴 timeout を待たない。
         assert!(near(t0.elapsed(), 330), "elapsed = {:?}", t0.elapsed());
     }
@@ -402,8 +418,15 @@ mod tests {
         let w = race(vec![d(1), d(2)], &[], RaceCfg::default(), attempter(script))
             .await
             .unwrap();
-        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 2)));
-        assert!(near(t0.elapsed(), 50), "elapsed = {:?} (10 fail + 40 ok)", t0.elapsed());
+        assert_eq!(
+            w.via,
+            Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 2))
+        );
+        assert!(
+            near(t0.elapsed(), 50),
+            "elapsed = {:?} (10 fail + 40 ok)",
+            t0.elapsed()
+        );
     }
 
     // ── eager relay ──────────────────────────────────────────────────────────
@@ -417,12 +440,21 @@ mod tests {
             (r("hub"), Script::Ok(ms(30))),
         ]);
         let t0 = Instant::now();
-        let w = race(vec![d(1), d(2), r("hub")], &[], RaceCfg::default(), attempter(script))
-            .await
-            .unwrap();
+        let w = race(
+            vec![d(1), d(2), r("hub")],
+            &[],
+            RaceCfg::default(),
+            attempter(script),
+        )
+        .await
+        .unwrap();
         assert_eq!(w.via, Via::Relay("hub".into()));
         assert_eq!(w.rtt, ms(30)); // relay 握手は 30ms（gate は adoption を遅らせるだけ）
-        assert!(near(t0.elapsed(), 500), "elapsed = {:?} (gate)", t0.elapsed());
+        assert!(
+            near(t0.elapsed(), 500),
+            "elapsed = {:?} (gate)",
+            t0.elapsed()
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -434,24 +466,40 @@ mod tests {
             (r("hub"), Script::Ok(ms(30))),
         ]);
         let t0 = Instant::now();
-        let w = race(vec![d(1), d(2), r("hub")], &[], RaceCfg::default(), attempter(script))
-            .await
-            .unwrap();
+        let w = race(
+            vec![d(1), d(2), r("hub")],
+            &[],
+            RaceCfg::default(),
+            attempter(script),
+        )
+        .await
+        .unwrap();
         assert_eq!(w.via, Via::Relay("hub".into()));
         // d(1)@10 fail→d(2) arm@10→fail@20、relay@30 完了で全 direct 決着済 → 30ms 採用。
-        assert!(near(t0.elapsed(), 30), "elapsed = {:?} (early)", t0.elapsed());
+        assert!(
+            near(t0.elapsed(), 30),
+            "elapsed = {:?} (early)",
+            t0.elapsed()
+        );
     }
 
     #[tokio::test(start_paused = true)]
     async fn direct_beats_already_connected_relay() {
         // relay は 20ms で握手済（hold）、direct は 100ms で完了 → direct 優先。
-        let script =
-            HashMap::from([(r("hub"), Script::Ok(ms(20))), (d(1), Script::Ok(ms(100)))]);
+        let script = HashMap::from([(r("hub"), Script::Ok(ms(20))), (d(1), Script::Ok(ms(100)))]);
         let t0 = Instant::now();
-        let w = race(vec![d(1), r("hub")], &[], RaceCfg::default(), attempter(script))
-            .await
-            .unwrap();
-        assert_eq!(w.via, Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1)));
+        let w = race(
+            vec![d(1), r("hub")],
+            &[],
+            RaceCfg::default(),
+            attempter(script),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            w.via,
+            Via::Direct(SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1))
+        );
         assert!(near(t0.elapsed(), 100), "elapsed = {:?}", t0.elapsed());
     }
 
@@ -467,7 +515,10 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn blackhole_without_relay_hits_deadline() {
         let script = HashMap::from([(d(1), Script::Fail(ms(9_000)))]); // deadline より長い
-        let cfg = RaceCfg { overall_deadline: ms(1_000), ..Default::default() };
+        let cfg = RaceCfg {
+            overall_deadline: ms(1_000),
+            ..Default::default()
+        };
         let t0 = Instant::now();
         let res = race(vec![d(1)], &[], cfg, attempter(script)).await;
         assert_eq!(res.unwrap_err(), RaceError::Deadline);

--- a/crates/unison-protocol/src/network/mod.rs
+++ b/crates/unison-protocol/src/network/mod.rs
@@ -25,6 +25,7 @@ pub mod conn_quinn;
 pub mod context;
 pub mod datagram_channel;
 pub mod datagram_dispatcher;
+pub mod dial;
 pub mod discovery;
 pub mod dispatch;
 pub mod dynamic;
@@ -46,6 +47,7 @@ pub use client::{ClientConnectionEvent, ClientConnectionEventReceiver, ProtocolC
 pub use conn::UnisonConn;
 pub use context::Principal;
 pub use datagram_channel::DatagramChannel;
+pub use dial::{AttemptOutcome, Candidate, RaceCfg, RaceError, Via, Winner, WldId};
 pub use discovery::{
     DISCOVERY_CHANNEL_NAME, GET_PROTOCOL_METHOD, GetProtocolRequest, ProtocolDocument,
     SCHEMA_UPDATED_EVENT, SchemaUpdatedEvent,

--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -400,7 +400,10 @@ impl QuicClient {
     /// loop 起動・identity oneshot 準備）。[`connect`](Self::connect) /
     /// [`connect_race`](Self::connect_race) 共通の後処理。
     async fn adopt_connection(&self, endpoint: Endpoint, connection: Connection) {
-        info!("Connected to QUIC server at {}", connection.remote_address());
+        info!(
+            "Connected to QUIC server at {}",
+            connection.remote_address()
+        );
 
         // Endpoint を保存（drop されると UDP ソケットが閉じて接続が切れる）
         *self.endpoint.lock().await = Some(endpoint);
@@ -493,9 +496,13 @@ impl QuicClient {
                             via: Via::Direct(addr),
                             rtt: t0.elapsed(),
                         },
-                        Err(_) => AttemptOutcome::Failed { via: Via::Direct(addr) },
+                        Err(_) => AttemptOutcome::Failed {
+                            via: Via::Direct(addr),
+                        },
                     },
-                    Err(_) => AttemptOutcome::Failed { via: Via::Direct(addr) },
+                    Err(_) => AttemptOutcome::Failed {
+                        via: Via::Direct(addr),
+                    },
                 }
             }
         })

--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -392,7 +392,15 @@ impl QuicClient {
             .await
             .context("Failed to establish QUIC connection")?;
 
-        info!("Connected to QUIC server at {}", addr);
+        self.adopt_connection(endpoint, connection).await;
+        Ok(())
+    }
+
+    /// 確立済み QUIC connection を client state に採用する（endpoint 保存・accept_bi
+    /// loop 起動・identity oneshot 準備）。[`connect`](Self::connect) /
+    /// [`connect_race`](Self::connect_race) 共通の後処理。
+    async fn adopt_connection(&self, endpoint: Endpoint, connection: Connection) {
+        info!("Connected to QUIC server at {}", connection.remote_address());
 
         // Endpoint を保存（drop されると UDP ソケットが閉じて接続が切れる）
         *self.endpoint.lock().await = Some(endpoint);
@@ -413,7 +421,88 @@ impl QuicClient {
             client_accept_bi_loop(connection_for_loop, identity_tx, server_channels).await;
         });
         self.response_tasks.lock().await.push(task);
+    }
 
+    /// 複数の direct 候補アドレスへ Happy Eyeballs v2 の staggered race で接続する
+    /// (ADR-020 §S6)。1 個の client Endpoint から候補を stagger 付きで並行 connect し、
+    /// 最初に握手完了した経路を採用、残りは cancel する。「全滅」を判定せず、死経路の
+    /// コストは stagger 1 tick で有界。
+    ///
+    /// **direct-first-cut**: IPv6 GUA (ADR-020 §D3-a = first-class direct) のみ race する。
+    /// IPv4 候補は doctrine 上まだ deferred (§D3) のため **warn して skip**（silent drop
+    /// はしない）。relay fallback は engine 側 relay-ready だが本メソッドでは未配線
+    /// (relay は別到達機構ゆえ Transport 抽象が要る = 次段)。
+    ///
+    /// `server_name` は全候補共通（= 同一 world の cert 名前検証に使う）。
+    pub async fn connect_race(
+        &self,
+        addrs: Vec<SocketAddr>,
+        server_name: &str,
+        cfg: super::dial::RaceCfg,
+    ) -> Result<()> {
+        use super::dial::{AttemptOutcome, Candidate, Via};
+
+        // IPv6 GUA のみ採用。IPv4 は §D3 で deferred ゆえ明示 skip（silent drop なし）。
+        let mut v6: Vec<SocketAddr> = Vec::new();
+        for a in addrs {
+            if a.is_ipv6() {
+                v6.push(a);
+            } else {
+                warn!("connect_race: IPv4 候補 {a} を skip (ADR-020 §D3: IPv4 deferred)");
+            }
+        }
+        if v6.is_empty() {
+            return Err(anyhow::anyhow!(
+                "connect_race: IPv6 direct 候補がありません"
+            ));
+        }
+
+        // SkipVerification は loopback のみ許可（connect と対称）。
+        if matches!(
+            self.trust_anchors,
+            super::trust::TrustAnchors::SkipVerification
+        ) && let Some(a) = v6.iter().find(|a| !a.ip().is_loopback())
+        {
+            return Err(anyhow::anyhow!(
+                "SkipVerification is restricted to loopback; got {a}"
+            ));
+        }
+
+        let client_config = Self::configure_client_with(self.trust_anchors.clone()).await?;
+
+        // v6 候補を 1 個の [::] endpoint から race する（複数 connect を同時発火）。
+        let mut endpoint = Endpoint::client("[::]:0".parse().unwrap())?;
+        endpoint.set_default_client_config(client_config);
+
+        let candidates: Vec<Candidate> = v6.into_iter().map(Candidate::Direct).collect();
+
+        let winner = super::dial::race::<Connection, _, _>(candidates, &[], cfg, |cand| {
+            // `&endpoint` を future に move（endpoint 本体は race 後に adopt するため保持）。
+            let ep = &endpoint;
+            async move {
+                let addr = match &cand {
+                    Candidate::Direct(a) => *a,
+                    // relay は direct-first-cut では未配線（次段の Transport 抽象で）。
+                    Candidate::Relay(_) => return AttemptOutcome::Failed { via: cand.via() },
+                };
+                let t0 = tokio::time::Instant::now();
+                match ep.connect(addr, server_name) {
+                    Ok(connecting) => match connecting.await {
+                        Ok(conn) => AttemptOutcome::Connected {
+                            transport: conn,
+                            via: Via::Direct(addr),
+                            rtt: t0.elapsed(),
+                        },
+                        Err(_) => AttemptOutcome::Failed { via: Via::Direct(addr) },
+                    },
+                    Err(_) => AttemptOutcome::Failed { via: Via::Direct(addr) },
+                }
+            }
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("connect_race failed: {e}"))?;
+
+        self.adopt_connection(endpoint, winner.transport).await;
         Ok(())
     }
 

--- a/crates/unison-protocol/tests/test_medium_connect_race.rs
+++ b/crates/unison-protocol/tests/test_medium_connect_race.rs
@@ -107,7 +107,10 @@ async fn connect_race_prefers_live_over_dead_decoy() -> Result<()> {
     client
         .connect_race(vec![dead, live], "::1", fast_cfg())
         .await?;
-    assert!(client.is_connected().await, "race should establish a live connection");
+    assert!(
+        client.is_connected().await,
+        "race should establish a live connection"
+    );
     // decoy には server が居ないため、ping-pong が成立すること自体が「race が live 経路を
     // 掴んだ」証明（dead を掴んでいたら open_channel/request が timeout する）。
     assert_ping_pong(&client).await?;

--- a/crates/unison-protocol/tests/test_medium_connect_race.rs
+++ b/crates/unison-protocol/tests/test_medium_connect_race.rs
@@ -1,0 +1,140 @@
+//! Medium x Integration: `connect_race`（Happy Eyeballs v2 dialer、ADR-020 §S6）e2e。
+//!
+//! engine の並行タイミングは `network::dial` の unit test が仮想時間で押さえている。
+//! ここは **実 quinn 相手** に「複数 direct 候補の staggered race が、死んだ decoy を
+//! 飛ばして生きている world へ実際に QUIC 接続を確立する」ことを round-trip で担保する。
+//!
+//! `#[ignore]` 付き — `cargo test -- --ignored` で実行。
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::{Value, json};
+use tokio::time::timeout;
+use tracing::{Level, info};
+
+use unison::network::MessageType;
+use unison::network::RaceCfg;
+use unison::network::channel::UnisonChannel;
+use unison::{ProtocolClient, ProtocolServer, ServerHandle};
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_test_writer()
+        .try_init();
+}
+
+/// `[::1]` に ping-pong エコーサーバーを起動し、`ServerHandle` と実 bind アドレスを返す。
+async fn start_echo_server() -> Result<(ServerHandle, SocketAddr)> {
+    let server = ProtocolServer::with_identity("connect-race-test", "1.0.0", "test");
+
+    server
+        .register_channel("ping-pong", |_ctx, stream| async move {
+            let channel: UnisonChannel = UnisonChannel::new(stream);
+            loop {
+                let msg = match channel.recv().await {
+                    Ok(msg) => msg,
+                    Err(_) => break,
+                };
+                if msg.msg_type != MessageType::Request {
+                    continue;
+                }
+                let payload = msg.payload_as_value().unwrap_or_default();
+                let message = payload
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Hello!");
+                let response = json!({ "message": format!("Pong: {}", message) });
+                if channel
+                    .send_response(msg.id, &msg.method, &response)
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            Ok(())
+        })
+        .await;
+
+    let handle = server.spawn_listen("[::1]:0").await?;
+    let local = handle.local_addr();
+    info!("connect-race echo server listening on {local}");
+    Ok((handle, local))
+}
+
+/// 接続済みクライアントで ping-pong を 1 往復して応答を検証する。
+async fn assert_ping_pong(client: &ProtocolClient) -> Result<()> {
+    let channel = client.open_channel("ping-pong").await?;
+    let resp: Value = timeout(
+        Duration::from_secs(5),
+        channel.request("ping", &json!({ "message": "race" })),
+    )
+    .await??;
+    assert_eq!(
+        resp.get("message").and_then(|v| v.as_str()),
+        Some("Pong: race"),
+        "ping-pong round-trip should echo via the raced connection"
+    );
+    Ok(())
+}
+
+/// テスト用に stagger を詰めた RaceCfg。
+fn fast_cfg() -> RaceCfg {
+    RaceCfg {
+        stagger: Duration::from_millis(100),
+        relay_handicap: Duration::from_millis(200),
+        overall_deadline: Duration::from_secs(5),
+    }
+}
+
+// ─────────────────────────────────────────────────
+// Test 1: 死んだ decoy を先頭に置いても、生きている world を race で掴む
+// ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "Medium: requires QUIC runtime"]
+async fn connect_race_prefers_live_over_dead_decoy() -> Result<()> {
+    init_tracing();
+
+    let (handle, live) = start_echo_server().await?;
+    // decoy = loopback port 1（誰も listen していない）を先頭候補に。
+    let dead: SocketAddr = "[::1]:1".parse().unwrap();
+
+    let client = ProtocolClient::new_default()?;
+    client
+        .connect_race(vec![dead, live], "::1", fast_cfg())
+        .await?;
+    assert!(client.is_connected().await, "race should establish a live connection");
+    // decoy には server が居ないため、ping-pong が成立すること自体が「race が live 経路を
+    // 掴んだ」証明（dead を掴んでいたら open_channel/request が timeout する）。
+    assert_ping_pong(&client).await?;
+
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────
+// Test 2: 単一 live 候補（sanity — 単発 direct と等価）
+// ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "Medium: requires QUIC runtime"]
+async fn connect_race_single_live_candidate() -> Result<()> {
+    init_tracing();
+
+    let (handle, live) = start_echo_server().await?;
+
+    let client = ProtocolClient::new_default()?;
+    client.connect_race(vec![live], "::1", fast_cfg()).await?;
+    assert!(client.is_connected().await);
+
+    assert_ping_pong(&client).await?;
+
+    client.disconnect().await?;
+    handle.shutdown().await?;
+    Ok(())
+}

--- a/design/README.md
+++ b/design/README.md
@@ -16,8 +16,15 @@
 | ドキュメント | 説明 | 対応仕様 |
 |------------|------|----------|
 | [architecture.md](architecture.md) | 全体アーキテクチャ設計詳細 | [spec/01](../spec/01-core-concept/SPEC.md) |
-| [packet.md](packet.md) | UnisonPacket実装仕様 | [spec/01](../spec/01-core-concept/SPEC.md) |
+| [packet.md](packet.md) | UnisonPacket実装仕様（バイナリパケット層） | [spec/01](../spec/01-core-concept/SPEC.md) |
+| [wire-format.md](wire-format.md) | Wire Format 設計（v0.9.0 buffa pivot） | — |
+| [quic-runtime.md](quic-runtime.md) | QUIC Runtime 統合 | — |
 | [connection-auth.md](connection-auth.md) | Connection-level auth primitive（mechanism/policy 分離） | — |
+| [datagram-channel.md](datagram-channel.md) | Datagram Channel 設計（best-effort lane、v0.10.0） | — |
+| [server-initiated-stream.md](server-initiated-stream.md) | Server-initiated reliable stream（`ServerToClient` を起こす、ADR-020 §S4） | — |
+| [happy-eyeballs-dial.md](happy-eyeballs-dial.md) | `connect_race` — Happy Eyeballs v2 staggered-race dialer（ADR-020 §S6） | — |
+| [swift-client-api.md](swift-client-api.md) | Swift Client SDK API 設計 | — |
+| [typescript-client-api.md](typescript-client-api.md) | TypeScript Client SDK API 設計（v1.0 Phase 3a） | — |
 | [test-strategy.md](test-strategy.md) | テスト戦略（3x3マトリクス） | — |
 
 ## 設計ドキュメントの書き方

--- a/design/happy-eyeballs-dial.md
+++ b/design/happy-eyeballs-dial.md
@@ -1,0 +1,159 @@
+# Happy Eyeballs v2 Dial — `connect_race`（staggered-race dialer）
+
+**status**: engine + direct adapter 実装済 2026-07-10（PR #86）/ relay adapter は次段
+**動機元**: chronista-hub ADR-020 §S6 の consume 側。到達性 ladder（§D3 `direct → relay`）を *逐次フォールバック* でなく **1 本の時間差レース** に畳む。
+**原則**: RFC 8305（Happy Eyeballs v2）の staggered-race を QUIC + relay に一般化。engine は **network 非依存**（data/calc/action の分離）で、実 I/O は薄い adapter に寄せる。
+
+---
+
+## 1. なぜ staggered race か — timeout ジレンマの構造的解消
+
+到達候補が複数あるとき（別アドレスの direct、hub 経由の relay）、素朴な実装は **逐次フォールバック**する: 候補 1 を per-endpoint timeout 付きで試し、ダメなら候補 2 へ。これは 1 本のノブ（timeout）に矛盾した要求を負わせる:
+
+- **短すぎる** → 生きているが遅い経路を「黒穴」と誤判定して捨てる（good-path 誤棄）。
+- **長すぎる** → 先頭候補が本当に黒穴のとき、次を試すまで数秒待たされる。
+
+staggered race はこのジレンマを**構造的に消す**。候補を「優先度と stagger（時間差）だけ違うもの」に均し、**全部を時間差で並行 arm** して、最初に握手完了した経路を採用・残りを cancel する。誰も「全滅」を判定しない。唯一の遅延ノブは**有界な stagger** だけで、死経路のコストは stagger 1 tick に収まる（先頭が黒穴でも、次候補は stagger 後に arm 済みで走っている）。
+
+|                        | 逐次フォールバック          | staggered race（本設計）        |
+| ---------------------- | --------------------------- | ------------------------------- |
+| 死経路のコスト         | per-endpoint timeout（数秒） | **stagger 1 tick（有界）**       |
+| good-but-slow 誤棄     | timeout 次第で起きる         | 起きない（待てば採用される）    |
+| 「全滅」判定           | 必要（誰かが timeout を持つ） | **不要**（in-flight ゼロで自然決着） |
+
+---
+
+## 2. 到達性 ladder — direct と relay（ADR-020 §D3）
+
+race に乗せる候補は 2 種（[`Candidate`]）:
+
+| candidate            | 到達手段                                             | 全滅時の hub 依存 |
+| -------------------- | ---------------------------------------------------- | ----------------- |
+| `Direct(SocketAddr)` | その addr へ QUIC 握手（IPv6 GUA /（将来）IPv4 / tailnet） | 無関係（§D3-a、hub data 不在） |
+| `Relay(WldId)`       | hub connection 上に `relay` channel を開き `open{to}` 宣言 = **別到達機構**（§D3-b、universal floor） | あり（hub の transient forwarding state） |
+
+`WldId` = location 独立の home-World 番地（ADR-020 D2）。relay 中継の宛先 routing key。
+
+**現状の実装スコープ（direct-first-cut）**: engine は direct/relay 両方を扱えるが、`QuicClient::connect_race` の adapter は **IPv6 GUA direct のみ**配線している。IPv4 は §D3 で deferred（warn して skip、silent drop はしない）。relay fallback は「別到達機構ゆえ `Transport` 抽象が要る」ため次段（§8）。
+
+---
+
+## 3. engine と I/O の分離（§S6 の data / calc / action）
+
+`network::dial` は 3 つに分かれる:
+
+- **`rank(candidates, my_addrs) -> Vec<Candidate>`** — 副作用ゼロの純関数（calc）。hub の opaque 順序付き候補（D2）に *消費側で* 意味を与える。
+- **`race<T, F, Fut>(candidates, my_addrs, cfg, attempt) -> Result<Winner<T>, RaceError>`** — network 非依存の generic engine（calc + タイマ）。実際の握手は呼び出し側が渡す `attempt: FnMut(Candidate) -> Fut` closure に閉じる。engine は `Candidate` の direct/relay 区別とタイマだけを見て、I/O を一切知らない。
+- **adapter（action）** — `QuicClient::connect_race` が `attempt` に quinn の `endpoint.connect(addr, sni)` を閉じ込める。relay adapter（次段）は hub channel open を閉じ込める。
+
+この分離の**帰結**: 並行タイミングの状態機械を `#[tokio::test(start_paused = true)]` の**仮想時間**で決定論的にテストできる（§7）。全 `attempt` 呼び出しが同一 future 型を返すため `FuturesUnordered<Fut>` で boxing 不要。
+
+### 主要型
+
+```rust
+pub enum Candidate { Direct(SocketAddr), Relay(WldId) }
+
+pub struct RaceCfg {
+    pub stagger: Duration,          // direct 候補間の時間差（RFC 8305 Connection Attempt Delay）
+    pub relay_handicap: Duration,   // 握手済 relay の adoption gate（direct に勝機を与える hold）
+    pub overall_deadline: Duration, // 全体の hard deadline
+}
+
+pub struct Winner<T> { pub transport: T, pub via: Via, pub rtt: Duration }
+pub enum Via { Direct(SocketAddr), Relay(WldId) }
+pub enum AttemptOutcome<T> { Connected { transport: T, via: Via, rtt: Duration }, Failed { via: Via } }
+pub enum RaceError { NoCandidates, AllFailed, Deadline }
+```
+
+---
+
+## 4. `race` 状態機械
+
+`rank` で並べ替えた候補を direct / relay に partition し、以下を回す:
+
+**arm の初期化**
+- relay を **t=0 で全て先行 arm**（eager、§5）。
+- 先頭 direct を 1 個 arm。
+- direct が皆無なら relay を hold しない（`gate_open = true`。勝機を与える相手が居ない）。
+
+**イベントループ（`tokio::select!`）**
+
+| # | イベント                    | 動作                                                                    |
+| - | --------------------------- | ----------------------------------------------------------------------- |
+| 1 | `stagger` tick              | 次の direct を並行 arm（前が未完でも構わず）。タイマを reset。            |
+| 2 | `gate`（`relay_handicap`）  | relay adoption を解禁。握手済 relay を hold 中なら **即採用**（failover +0 RTT）。 |
+| 3 | 握手が resolve（`Connected`） | **direct** → 即採用（hold 中 relay より優先）。**relay** → gate 開なら即採用、閉なら `relay_ready` に hold。 |
+| 3'| 握手が resolve（`Failed`）   | **direct 失敗**なら stagger を待たず**次 direct を即 arm**（RFC 8305 の fast-fail chain）。relay 失敗は放置。 |
+| 4 | `overall_deadline`          | in-flight のまま時間切れ → 握手済 relay を拾うか [`RaceError::Deadline`]。 |
+
+**終了判定**: `outstanding == 0 && directs.is_empty()`（進行中ゼロ かつ arm 待ち direct なし）→ 握手済 relay を hold していれば即採用（handicap を待たない）、無ければ [`RaceError::AllFailed`]。黒穴/拒否の timeout を待たずに返る。
+
+### タイムライン例（`RaceCfg::default()`: stagger=250ms / handicap=500ms）
+
+| シナリオ                                  | 結果                     | 所要（仮想時間） |
+| ----------------------------------------- | ------------------------ | ---------------- |
+| 先頭 direct が 50ms で成功                | direct 採用（d(2) は arm 前） | ~50ms            |
+| 先頭 direct 黒穴・次 direct 80ms で成功    | 次 direct 採用           | ~330ms（stagger 250 + 80、黒穴 timeout 待たず） |
+| 先頭 direct 10ms fast-fail・次 40ms 成功  | 次 direct 採用           | ~50ms（fail chain、stagger 待たず） |
+| direct 両方黒穴・relay 30ms 握手済        | relay 採用（gate で）    | ~500ms（gate）、rtt=30ms |
+| direct 両方 fast-fail・relay 30ms 握手済  | relay 早期採用           | ~30ms（全 direct 決着済）|
+| relay 20ms 握手済・direct 100ms 成功      | **direct 採用**（hold 上書き） | ~100ms           |
+
+---
+
+## 5. eager relay — doctrine default（ADR-020 §S6、user 確定 2026-07-07）
+
+relay 候補があれば **t=0 で先行 arm** する（既存 hub connection 上の open ≈ 1 RTT で握手が済む）。握手が済んでも `relay_handicap` 経過まで **採用を hold** し、in-flight の direct に勝機を与える:
+
+- direct が hold 中に完了すれば **direct 採用**（relay は drop で tear down）。
+- direct が全滅 or handicap 経過なら **relay を即採用** — relay は既に握手済なので failover は **+0 RTT**。
+
+`relay_handicap = 0` なら relay を待たせず即採用、大きいほど direct 優先が強い。「relay を後から慌てて握る」のでなく「先に握って採用を遅らせる」ことで、direct 失敗時の failover コストをゼロにするのが狙い。
+
+---
+
+## 6. 勝者以外の tear down 契約（境界①）
+
+engine は敗者を **future の drop** で cancel する（`FuturesUnordered` から落とすだけ）。ゆえに `Winner<T>` / 進行中 attempt が保持する transport `T` は、**Drop 時に relay stream を確実に close** する実装でなければならない:
+
+- hub は dialer の `open` で `wld_id → ctx` の transient forwarding state を持つ（`unison_server.rs`）。放置すると握手ドロップ検知まで残り、D1 の「durable 0」を一瞬でも欠く。
+- direct（`quinn::Connection`）は drop で UDP が閉じるため追加処理不要。
+
+```rust
+enum Transport { Direct(quinn::Connection), Relay(UnisonChannel) }
+impl Drop for Transport { /* Relay は close して hub transient を即消す */ }
+```
+
+→ relay adapter を配線する次段（§8）で `Transport` enum と `Drop` を実装する。**この契約を破ると hub 側にゴミ state が溜まる**ため、relay 配線時の最重要チェック項目。
+
+---
+
+## 7. テスト戦略
+
+| level        | 場所                                          | 何を担保するか                                       | 実行 |
+| ------------ | --------------------------------------------- | ---------------------------------------------------- | ---- |
+| **unit**     | `network::dial::tests`（10 件）               | engine の状態機械。**仮想時間**（`start_paused = true`）で scripted latency を `sleep` が演じ、実時間 0・決定論的に回る。 | 常時 |
+| **medium**   | `tests/test_medium_connect_race.rs`（2 件）   | **実 quinn** で staggered race が死んだ decoy を飛ばし生きた world へ QUIC round-trip する。 | `#[ignore]`（`cargo test -- --ignored`） |
+
+unit test が押さえる不変条件: first-direct-wins / 黒穴 direct = stagger 1 tick / fast-fail chain / eager relay の gate 採用 / 早期採用 / direct が hold relay に勝つ / AllFailed / Deadline / rank の relay-last。
+
+---
+
+## 8. Open points / 次段
+
+- **relay adapter 配線** — `Transport` enum + `Drop`（§6）を実装し、`Candidate::Relay` を hub channel open に閉じ込める。これで direct 全滅時の relay failover が実効化する。
+- **`rank` の高度化**（`rank` 内 TODO）:
+  - 同一 prefix（/64, /48）共有の direct GUA を先頭へ（同一サイト・低 RTT 期待）。
+  - IPv4 導入時は family interleave（v6, v4, …）で片 family 黒穴の頭独占を防ぐ。
+- **win-cache**（ADR-020 Open point #1「庭師の actual reachability」）— `Winner.rtt` を実測 RTT として蓄積し、stagger を適応化（RFC 下限 100–150ms まで詰める）。
+- **IPv4 / tailnet direct**（§D3）— 現状 IPv6 GUA のみ。adapter の family skip を解除する。
+
+---
+
+## 関連
+
+- `crates/unison-protocol/src/network/dial.rs` — engine（`rank` / `race`）+ unit test
+- `crates/unison-protocol/src/network/quic.rs` — `QuicClient::connect_race`（direct adapter）
+- `crates/unison-protocol/src/network/client.rs` — `ProtocolClient::connect_race`（`after_connect` 共有）
+- `crates/unison-protocol/tests/test_medium_connect_race.rs` — medium integration
+- [server-initiated-stream.md](server-initiated-stream.md) — 同じ ADR-020 系（§S4 relay substrate）の SSOT


### PR DESCRIPTION
chronista-hub ADR-020 §S6 の consume 側。到達性 ladder (direct → relay) を逐次フォールバックでなく **1 本の staggered race** に畳む Happy Eyeballs v2 (RFC 8305) dialer。

## 2 commits

**1. engine (`network::dial`)** — network 非依存の generic `race<T,F,Fut>`
- 実 I/O (quinn connect / relay open) は `attempt` closure に閉じ、engine は Candidate の direct/relay 区別とタイマだけ見る (data/calc/action 分離)
- **eager relay arm** (doctrine default): relay を t=0 で先行 arm・握手だけ済ませ、`relay_handicap` 経過まで採用 hold → direct 全滅でも failover **+0 RTT**。direct が hold 中に完了すれば direct 優先
- 黒穴は待たない (direct 失敗で次を即 arm)。「全滅」を判定せず per-endpoint timeout ジレンマを消す
- `rank()` pure fn / `Winner{via,rtt}` が win-cache → 庭師 liveness の actual reachability を供給
- 敗者は future drop で cancel、`T::drop` で relay stream close (hub transient tear down, D1 durable 0)

**2. adapter (`QuicClient`/`ProtocolClient::connect_race`)** — direct-first-cut
- IPv6 GUA (§D3-a first-class) を 1 個の `[::]` Endpoint から並行 dial。IPv4 は §D3 deferred で warn+skip (silent drop なし)、relay は次段 (Transport 抽象)
- `connect()` の後処理を `adopt_connection()`/`after_connect()` に抽出して共有 (挙動不変)

## test (実測)
- engine: 仮想時間 (tokio start_paused) で **unit 10/10** — 死経路コスト=stagger 1 tick / eager relay +0 RTT / direct が握手済 relay に優先 / fast-fail 即 chain / AllFailed vs Deadline
- adapter: 実 QUIC **e2e 2/2** (`test_medium_connect_race`) — dead decoy を先頭に置いても live world を race で掴み ping-pong 往復
- 回帰なし: lib 174 tests + dualstack e2e 5 tests green、変更コードは clippy clean

## scope 外 (次段)
relay の本配線 (`Transport{Direct|Relay}` 抽象) / IPv4 / relay→direct 昇格 (QUIC migration)。dev-dep に tokio `test-util` 追加 (仮想時間)。

doctrine: chronista-hub ADR-020 §S6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdaF57EnSzvPPY73kiqyGu