### PR TITLE
chore(release): 1.6.0 — connect_race (Happy Eyeballs v2 dialer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-11 — connect_race: Happy Eyeballs v2 staggered-race dialer
+
+> 複数 direct 候補への接続を逐次フォールバックでなく 1 本の時間差レース（RFC 8305 型）に畳む
+> dialer（ADR-020 §S6 の consume 側）。direct-first-cut = IPv6 GUA direct のみ、relay fallback
+> は次段（`Transport` 抽象）。SemVer minor（additive・opt-in、既存 `connect` API 不変）。
+>
+> 設計: `design/happy-eyeballs-dial.md`（SSOT）
+
 ### Added
 
 - **connect_race — Happy Eyeballs v2 staggered-race dialer**（`network::dial` / `network::client` /

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- workspace version 1.5.0 → **1.6.0**（SemVer minor: connect_race は additive・opt-in、既存 `connect` API 不変）
- CHANGELOG `[Unreleased]` → `[1.6.0] - 2026-07-11` を stamp

## Release 内容（PR #86）

connect_race — Happy Eyeballs v2 staggered-race dialer（engine + direct adapter、ADR-020 §S6）。
設計 SSOT: `design/happy-eyeballs-dial.md`。

## マージ後の手順

1. `v1.6.0` annotated tag を squash commit に付与して push
2. `cargo publish -p club-unison`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zjeS2WWC7kRYczCn3QFSn