### PR TITLE
chore(mcp): rmcp を 2.2.0 へ更新 + 未使用 macros feature を削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **unison-mcp: rmcp を最新 2 系（2.2.0）へ更新**（`1.7` → `2`）: MCP 公式 Rust SDK を 2 系に追従。
+  破壊的変更は content 型のみ — `Content`（= `Annotated<RawContent>`）→ **`ContentBlock`**（enum 直、
+  `.raw` ラッパ廃止）にリネーム。`Content::text` → `ContentBlock::text`、テストの `c.raw` /
+  `RawContent::Text` → `c` / `ContentBlock::Text` に追従。`Tool::new` / `ServerHandler` / `ErrorData` /
+  `schema_for_type` の API は不変。
+- **unison-mcp: 未使用の rmcp `macros` feature を削除**: `#[tool]` / `#[tool_router]` マクロは撤去済で
+  `ServerHandler` を手動 impl しているため、`macros` は dead weight だった。rmcp の `default`
+  （`base64` / `macros` / `server`）に `macros` が含まれるため `default-features = false` にして
+  `server` / `transport-io` / `base64` のみを明示列挙し、`rmcp-macros` proc-macro を依存グラフから
+  除去（ビルド短縮・Minimum を保つ）。
+
+  いずれも `unison-mcp`（`publish = false` の MCP bridge crate）内に閉じ、公開 `club-unison` API への
+  影響はなし。
+
 ## [1.6.0] - 2026-07-11 — connect_race: Happy Eyeballs v2 staggered-race dialer
 
 > 複数 direct 候補への接続を逐次フォールバックでなく 1 本の時間差レース（RFC 8305 型）に畳む

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,9 @@ crc32fast = "1.5"
 clap = { version = "4.6", features = ["derive", "cargo", "color"] }
 
 # MCP (Model Context Protocol) — rmcp 公式 Rust SDK
-rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
+# default = [base64, macros, server]。macros（`#[tool]` 系）は未使用のため
+# default-features = false で切り、必要な feature のみ明示列挙する。
+rmcp = { version = "2", default-features = false, features = ["server", "transport-io", "base64"] }
 schemars = "1"
 
 # Utilities

--- a/crates/unison-mcp/src/tools.rs
+++ b/crates/unison-mcp/src/tools.rs
@@ -257,7 +257,7 @@ async fn handle_ping(bridge: &UnisonBridge, args: PingArgs) -> Result<CallToolRe
     let (_client, endpoint) = connect_client(bridge, args.endpoint.as_deref(), args.trust).await?;
     let trust = bridge.resolve_trust(args.trust, &endpoint);
     let msg = format!("✅ connected to {endpoint} (trust={trust:?})");
-    Ok(CallToolResult::success(vec![Content::text(msg)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(msg)]))
 }
 
 async fn handle_call(bridge: &UnisonBridge, args: CallArgs) -> Result<CallToolResult, McpError> {
@@ -278,7 +278,7 @@ async fn handle_call(bridge: &UnisonBridge, args: CallArgs) -> Result<CallToolRe
         "method": args.method,
         "response": response,
     });
-    Ok(CallToolResult::success(vec![Content::text(
+    Ok(CallToolResult::success(vec![ContentBlock::text(
         result.to_string(),
     )]))
 }
@@ -323,7 +323,7 @@ async fn handle_discover(
         "channels": channels,
     });
 
-    Ok(CallToolResult::success(vec![Content::text(
+    Ok(CallToolResult::success(vec![ContentBlock::text(
         serde_json::to_string_pretty(&summary).unwrap_or_else(|_| summary.to_string()),
     )]))
 }
@@ -388,7 +388,7 @@ async fn handle_synthesized(
         "method": method,
         "response": response,
     });
-    Ok(CallToolResult::success(vec![Content::text(
+    Ok(CallToolResult::success(vec![ContentBlock::text(
         serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()),
     )]))
 }

--- a/crates/unison-mcp/tests/test_integ_synthesis.rs
+++ b/crates/unison-mcp/tests/test_integ_synthesis.rs
@@ -187,8 +187,8 @@ async fn test_e2e_synthesis_invoke_synthesized_tool_round_trip() -> Result<()> {
 
     // CallToolResult の content[0] が text、 JSON parse して中身を assert
     let content_text = match result.content.first() {
-        Some(c) => match &c.raw {
-            rmcp::model::RawContent::Text(t) => t.text.clone(),
+        Some(c) => match c {
+            rmcp::model::ContentBlock::Text(t) => t.text.clone(),
             _ => panic!("expected text content"),
         },
         None => panic!("no content in CallToolResult"),


### PR DESCRIPTION
## 概要
`unison-mcp` の MCP SDK `rmcp` を最新 2 系（2.2.0）へ更新。Edge ブランチ `nightly` 宛。

## 変更
- **rmcp `1.7` → `2`（2.2.0）**。破壊的変更は content 型のみ:
  - `Content`（= `Annotated<RawContent>`）→ **`ContentBlock`**（`.raw` ラッパ廃止）にリネーム。
  - `Content::text` → `ContentBlock::text`、テストの `c.raw` / `RawContent::Text` → `c` / `ContentBlock::Text`。
  - `Tool::new` / `ServerHandler` / `ErrorData` / `schema_for_type` の API は不変。
- **未使用の `macros` feature を削除**: `#[tool]` / `#[tool_router]` は撤去済で手動 `ServerHandler` 実装のため dead weight。rmcp の `default`(base64/macros/server) に macros が含まれるので `default-features = false` にし `server` / `transport-io` / `base64` のみ明示列挙 → `rmcp-macros` proc-macro を依存グラフから除去。
- CHANGELOG `[Unreleased]` に記録。

## 検証
- `unison-mcp` lib 37 passed / E2E（`--ignored`）4 passed
- `cargo test --workspace` 全 green（1.6.0 追いつかせ済み nightly 相当で実測）
- `cargo clippy --lib --workspace -- -D warnings` クリーン

## メモ
- diff は 4 ファイルのみ（rmcp 変更に閉じる）。`unison-mcp` は `publish = false` のため公開 `club-unison` API への影響なし。
- Base = `nightly`（「新規実装はまず nightly へ PR」の運用に従う）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
