### PR TITLE
ci: nightly を CI trigger に追加（Edge に Rust CI ゲートを付ける）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, nightly]
   pull_request:
-    branches: [main]
+    branches: [main, nightly]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## 概要
`nightly`（Edge ブランチ）宛の PR / push に Rust CI が回るよう、`ci.yml` の trigger に `nightly` を追加。

## 背景
現状 `ci.yml` は `push` / `pull_request` とも `branches: [main]` 限定。「新規実装はまず nightly へ PR」の運用に切り替えたが、**nightly 宛 PR には Format / Clippy / Test / MSRV / Cargo Deny が発火しない**ゲート抜けが生じていた（例: #88 は automation チェックのみで mergeable=CLEAN 化）。

## 変更
- `on.push.branches`: `[main]` → `[main, nightly]`
- `on.pull_request.branches`: `[main]` → `[main, nightly]`

## メモ
- `pull_request` の `branches:` フィルタは **base ブランチ側の `ci.yml`** で評価されるため、この変更が nightly に入って初めて「nightly 宛 PR」に CI が効く（この PR 自体は現行 main-only 設定下なので実 CI は付かない）。マージ後の nightly PR から有効。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
