### PR TITLE
fix(quic): accept loop の handshake await 失敗が acceptor 全体を殺す片肺死を根治

### DIFF
--- a/crates/unison-protocol/src/network/quic.rs
+++ b/crates/unison-protocol/src/network/quic.rs
@@ -763,14 +763,25 @@ impl QuicServer {
         info!("QUIC server listening for connections");
 
         while let Some(connecting) = endpoint.accept().await {
-            let connection = connecting.await?;
-            let remote_addr = connection.remote_address();
-            info!("New QUIC connection from: {}", remote_addr);
-
+            // handshake 完了 (`connecting.await`) は **per-connection task 内**で行う。
+            // 以前は accept loop 内で `connecting.await?` していたため、incoming handshake が
+            // 1 つでも失敗すると `?` が accept loop 全体を終了させ、以降の新規接続を一切
+            // 受け付けなくなる「片肺死」が起きていた (既存の spawn 済み接続だけ生存)。
+            // 例: federation direct-dial の cert mismatch (`UnknownIssuer`) や ALPN mismatch。
+            // 修正 2026-07-13、回帰テスト test_medium_accept_resilience、creo
+            // mem_1CcvYA5TRF4EcFafbyKqPg。
             let server = Arc::clone(&self.server);
             let ctx = Arc::new(ConnectionContext::new());
-            let conn: Arc<dyn UnisonConn> = Arc::new(connection);
             tokio::spawn(async move {
+                let connection = match connecting.await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!("QUIC handshake failed (accept loop 継続): {}", e);
+                        return;
+                    }
+                };
+                info!("New QUIC connection from: {}", connection.remote_address());
+                let conn: Arc<dyn UnisonConn> = Arc::new(connection);
                 if let Err(e) = handle_connection(conn, server, ctx).await {
                     error!("Connection error: {}", e);
                 }
@@ -797,14 +808,20 @@ impl QuicServer {
                 connecting = endpoint.accept() => {
                     match connecting {
                         Some(connecting) => {
-                            let connection = connecting.await?;
-                            let remote_addr = connection.remote_address();
-                            info!("New QUIC connection from: {}", remote_addr);
-
+                            // handshake 完了は per-connection task 内で行う (start() と同じ理由で
+                            // accept loop を守る = 片肺死の根治、2026-07-13、mem_1CcvYA5TRF4EcFafbyKqPg)。
                             let server = Arc::clone(&self.server);
                             let ctx = Arc::new(ConnectionContext::new());
-                            let conn: Arc<dyn UnisonConn> = Arc::new(connection);
                             tokio::spawn(async move {
+                                let connection = match connecting.await {
+                                    Ok(c) => c,
+                                    Err(e) => {
+                                        warn!("QUIC handshake failed (accept loop 継続): {}", e);
+                                        return;
+                                    }
+                                };
+                                info!("New QUIC connection from: {}", connection.remote_address());
+                                let conn: Arc<dyn UnisonConn> = Arc::new(connection);
                                 if let Err(e) = handle_connection(conn, server, ctx).await {
                                     error!("Connection error: {}", e);
                                 }

--- a/crates/unison-protocol/tests/test_medium_accept_resilience.rs
+++ b/crates/unison-protocol/tests/test_medium_accept_resilience.rs
@@ -1,0 +1,102 @@
+//! accept loop resilience の回帰テスト。
+//!
+//! **バグ (2026-07-13 特定)**: `QuicServer::start()` / `start_with_shutdown()` の accept loop が
+//! `let connection = connecting.await?;` を **spawn の前・loop の中**で await していた。
+//! incoming handshake が 1 つでも失敗すると `?` が accept loop 全体を終了させ、以降の新規接続を
+//! 一切受け付けなくなる (既存の spawn 済み接続は生存 = 「片肺死」)。
+//!
+//! 実害: VP daemon で federation direct-dial (peer が dev cert の :32000 へ System trust で接続 →
+//! `UnknownIssuer` で handshake abort) が incoming failed handshake を生み、acceptor を殺していた。
+//! daemon.kdl.log に「Daemon Unison サーバーエラー: ...handshake failed...」→ watchdog self-heal
+//! の連鎖が 10+ 回記録 (creo mem_1CcvYA5TRF4EcFafbyKqPg)。
+//!
+//! このテストは「**失敗した handshake の後も acceptor が新規接続を受け続ける**」ことを保証する。
+//! 失敗 handshake は ALPN mismatch (空 ALPN の旧 client 相当) で決定論的に起こす
+//! (test_alpn_enforcement と同じ機序、handshake のみで完結 = 軽量)。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use quinn::{ClientConfig, Endpoint};
+use rustls::ClientConfig as RustlsClientConfig;
+use tokio::time::timeout;
+
+use unison::network::trust::TrustAnchors;
+use unison::network::{ProtocolServer, QuicServer};
+
+/// dev_localhost cert の server を spawn し、接続用アドレスを返す。
+async fn spawn_server() -> String {
+    let server = Arc::new(ProtocolServer::with_identity(
+        "accept-resilience",
+        "1.0.0",
+        "test",
+    ));
+    let mut quic = QuicServer::new(Arc::clone(&server));
+    quic.bind("[::1]:0").await.expect("bind");
+    let local = quic.local_addr().expect("local_addr");
+    let addr = format!("[{}]:{}", local.ip(), local.port());
+    tokio::spawn(async move {
+        let _ = quic.start().await;
+    });
+    addr
+}
+
+/// 指定 ALPN で client を作り server へ接続を試みる (handshake まで)。
+/// 空 ALPN = handshake 失敗 (旧 client 相当)、`["unison"]` = 成功。
+async fn try_connect(addr: &str, alpn: &[&str]) -> Result<(), String> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let mut rustls_cfg: RustlsClientConfig = (*TrustAnchors::SkipVerification
+        .build_client_config()
+        .unwrap())
+    .clone();
+    rustls_cfg.alpn_protocols = alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
+
+    let crypto = quinn::crypto::rustls::QuicClientConfig::try_from(rustls_cfg)
+        .map_err(|e| format!("client crypto config: {e}"))?;
+    let client_config = ClientConfig::new(Arc::new(crypto));
+
+    let mut endpoint = Endpoint::client("[::]:0".parse().unwrap()).map_err(|e| e.to_string())?;
+    endpoint.set_default_client_config(client_config);
+
+    let sockaddr: std::net::SocketAddr = addr
+        .parse()
+        .map_err(|e: std::net::AddrParseError| e.to_string())?;
+    timeout(Duration::from_secs(5), async {
+        endpoint
+            .connect(sockaddr, "localhost")
+            .map_err(|e| e.to_string())?
+            .await
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|_| "connect timeout".to_string())?
+    .map(|_conn| ())
+}
+
+/// **回帰**: 失敗した handshake は当該接続に閉じ、accept loop を殺してはならない。
+/// バグ版 (`connecting.await?` が loop 内) では 3 回目の good connect が timeout する。
+#[tokio::test]
+async fn acceptor_survives_failed_handshake() {
+    let addr = spawn_server().await;
+
+    // 1. 正常 client → 接続成立 (acceptor 生存の sanity)
+    let first = try_connect(&addr, &["unison"]).await;
+    assert!(first.is_ok(), "初回の good connect は成立すべき: {first:?}");
+
+    // 2. 空 ALPN client → handshake 失敗 (これが acceptor を殺してはならない)
+    let bad = try_connect(&addr, &[]).await;
+    assert!(bad.is_err(), "空 ALPN client は handshake 拒否されるべき");
+
+    // 失敗 handshake を server 側 accept loop が処理しきる猶予 (buggy 版なら start() が exit)。
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // 3. 再び正常 client → **まだ**接続できること (バグ版はここで timeout)。
+    let after = try_connect(&addr, &["unison"]).await;
+    assert!(
+        after.is_ok(),
+        "失敗 handshake の後も acceptor は新規接続を受け続けるべき（accept loop が死んでいる）: {after:?}"
+    );
+}


### PR DESCRIPTION
## 根本原因（10+ 回のログ実証）

`QuicServer::start()`（`quic.rs:766`）と `start_with_shutdown()`（`:800`）の accept loop:

```rust
while let Some(connecting) = endpoint.accept().await {
    let connection = connecting.await?;   // ← handshake を loop 内で await + ? で伝播
    ...
    tokio::spawn(async move { handle_connection(...) });
}
```

`connecting.await`（QUIC/TLS handshake の完了待ち）が **spawn の前・accept loop の中**で await され、`?` で伝播していた。incoming handshake が 1 つでも失敗すると `?` が `start()` から抜け、**accept loop 全体が終了** → 以降の新規接続を一切受け付けなくなる。既存の spawn 済み接続は生存するため「片肺死」（HTTP 生存・QUIC accept 死）になる。

## 実害

VP daemon で federation direct-dial（peer が dev cert の `:32000` へ System trust で接続 → handshake が `error 48: invalid peer certificate: UnknownIssuer` で abort）が incoming failed handshake を生み、この daemon の acceptor を殺していた。

`daemon.kdl.log` に以下の連鎖が**今日だけで 5 回、通算 10+ 回**記録:
```
ERROR Daemon Unison サーバーエラー: aborted by peer: ...handshake failed: UnknownIssuer
  ↓ ~30-90s (watchdog の次 probe)
WARN QUIC liveness probe 失敗 (1/3)→(2/3)→(3/3)
  ↓
ERROR QUIC 面の wedge を検知 → self-heal 再起動
```
HTTP は生存する片肺死のため health check で検知不能で、watchdog self-heal（VP #730）は**対症療法**だった。federation がアクティブなほど direct-dial が増え wedge が頻発する。

（creo `mem_1CcvYA5TRF4EcFafbyKqPg` の「真因未確定」を本 PR で確定・根治。当初の `#726 lane_change_tx deadlock` 仮説はコード精読で反証済みだった。）

## 修正

`connecting.await` を **per-connection の spawn task 内**へ移動し、handshake 失敗を `warn!` + `return` で当該接続に閉じ込める。accept loop は endpoint が閉じるまで生存する。`start()` と `start_with_shutdown()` の両方に適用。

## テスト

`test_medium_accept_resilience`（新規、非 `#[ignore]`、handshake のみで決定論的）: good → 失敗 handshake（空 ALPN）→ good の 3 段で、失敗後も acceptor が新規接続を受け続けることを保証。**修正前は 3 段目が `connect timeout` で FAIL**、修正後 PASS。

全 suite green（174 lib + 全 integration、accept-path medium テスト connect_race / server_initiated / quic_lifecycle / client_events も `--include-ignored` で green）、clippy / fmt clean。

## 配布

crates.io release（v1.6.1）→ VP の `unison` 依存 bump → VP daemon 再ビルドで live 反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiEgth6ey7EDtCYbSSz1Y5