### PR TITLE
feat(mcp): rmcp 2 系機能の還元 — typed I/O + live re-discovery + elicitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@
 
 ## [Unreleased]
 
+### Added
+
+- **unison-mcp: rmcp 2 系機能の還元 — typed I/O + live bridge 化**:
+  - KDL `returns` block → MCP `Tool.output_schema` 合成。synthesized tools が入出力とも
+    typed になり、client が `structuredContent` を検証できる（input と同一 converter =
+    `mapping::fields_to_object_schema`、型対応が入出力で完全一致）。
+  - 全 tool の結果を `structuredContent` で返却（text content は互換 mirror）。synthesized
+    tools は response そのものを structured で返し、output_schema と形が一致する。
+  - static tools に `ToolAnnotations`（ping/discover = read-only + idempotent、全 tool
+    open-world）、synthesized tools に `title`（= sanitize 前の `channel.method` 表示名）。
+  - **live re-discovery**: `unison_discover` が default endpoint への成功時に bridge の
+    discovery を置き換え、synthesized tool set を MCP session 中に更新（= server の schema
+    進化に追従）。protocol hash 変化時は `notifications/tools/list_changed` を発行
+    （`listChanged` capability 宣言済み）。`UnisonBridge.discovered` は `RwLock` 化。
+  - **endpoint elicitation**: endpoint が config にも tool arg にも無い場合、elicitation
+    対応 client にはその場で接続先を質問（`Peer::elicit`、rmcp feature `elicitation` +
+    `schemars` を追加）。非対応/拒否/失敗は従来どおり invalid_request エラー。
+
 ### Changed
 
 - **unison-mcp: rmcp を最新 2 系（2.2.0）へ更新**（`1.7` → `2`）: MCP 公式 Rust SDK を 2 系に追従。

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ clap = { version = "4.6", features = ["derive", "cargo", "color"] }
 # MCP (Model Context Protocol) — rmcp 公式 Rust SDK
 # default = [base64, macros, server]。macros（`#[tool]` 系）は未使用のため
 # default-features = false で切り、必要な feature のみ明示列挙する。
-rmcp = { version = "2", default-features = false, features = ["server", "transport-io", "base64"] }
+# elicitation + schemars は `Peer::elicit`（endpoint 未設定時のユーザー質問）用。
+rmcp = { version = "2", default-features = false, features = ["server", "transport-io", "base64", "elicitation", "schemars"] }
 schemars = "1"
 
 # Utilities

--- a/crates/unison-mcp/README.md
+++ b/crates/unison-mcp/README.md
@@ -4,7 +4,7 @@ MCP (Model Context Protocol) bridge for the Unison Protocol — discovers a serv
 
 ## Status
 
-**v1.1.0 — Hailing α GA** (= 2026-05-28)
+**rmcp 2.x 世代** (= 2026-07-14、 MCP spec 2025-06-18+ の機能を還元)
 
 | feature | status |
 |---|---|
@@ -12,6 +12,11 @@ MCP (Model Context Protocol) bridge for the Unison Protocol — discovers a serv
 | `unison_call` (= static escape hatch、 generic、 schema 検証なし) | ✅ |
 | `unison_discover` (= unison.discovery 経由で server KDL を fetch + summary) | ✅ |
 | Synthesized typed tools (= `unison_<channel>_<method>`、 起動時 discovery 成功時) | ✅ |
+| Synthesized `output_schema` (= KDL `returns` block から合成、 入出力とも typed) | ✅ |
+| `structuredContent` results (= 全 tool、 text は互換 mirror) | ✅ |
+| Tool annotations + title (= read-only/idempotent hint、 `channel.method` 表示名) | ✅ |
+| Live re-discovery (= `unison_discover` が default endpoint の tool set を refresh、 hash 変化で `tools/list_changed`) | ✅ |
+| Endpoint elicitation (= endpoint 未設定時、 対応 client へその場で質問) | ✅ |
 | MCP E2E demo (= Claude Code から実機 round-trip) | ✅ (DEMO.md 参照) |
 
 ## Install
@@ -58,6 +63,11 @@ See [`examples/unison.json`](examples/unison.json):
 
 ## Tools
 
+全 tool の結果は `structuredContent`（= 機械可読 JSON、 text content は互換 mirror）で返る。
+synthesized tools は KDL `returns` block から `output_schema` を宣言するので、 client 側で
+結果の型検証が可能。 endpoint が config にも tool arg にも無い場合、 elicitation 対応
+client にはその場で接続先を質問する（非対応 client は従来どおりエラー）。
+
 ### `unison_ping`
 
 Verify connectivity to an endpoint.
@@ -79,9 +89,15 @@ Send any request to a channel. No schema validation — useful for debugging or 
 | `payload` | JSON | yes |
 | `trust` | `"skip"` / `"system"` | no |
 
-### `unison_discover` (NEW)
+### `unison_discover`
 
 Fetch the server's protocol KDL via the `unison.discovery` channel, return a summary of channels / requests / events.
+
+**Refresh semantics**: default endpoint (= config の endpoint) に対する discover は、
+成功時に bridge の discovery を置き換えて synthesized tool set を更新する
+(= server の schema 進化に MCP session 中に追従)。 protocol hash が変わった場合は
+`notifications/tools/list_changed` を client に送る。 明示的に別 endpoint を指定した
+discover は one-off 照会で、 state を変えない (= response の `refreshed` field で判別可)。
 
 | Arg | Type | Required |
 |---|---|---|

--- a/crates/unison-mcp/src/bridge.rs
+++ b/crates/unison-mcp/src/bridge.rs
@@ -4,12 +4,16 @@
 //! fetch、 schema を `discovered` field に保持)。 これにより `tools.rs` の `list_tools`
 //! が synthesized typed tools を返せるようになる。
 //!
+//! discovery は起動時 1 回で終わりではなく **live** — `unison_discover` が default
+//! endpoint に対して成功すると [`UnisonBridge::set_discovered`] で置き換わり、
+//! synthesized tool set が MCP session 中に更新される (= server の schema 進化に追従)。
+//!
 //! Discovery failure (= endpoint 未指定 / 接続失敗 / KDL parse 失敗) は warn log
 //! で continue、 static escape hatch tools (ping/call/discover) のみで動作。 これに
 //! より agent 起動時に 「discovery server がまだ準備中」 の場合でも MCP server 自身は
 //! 起動できる (= 部分動作の resilience)。
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 
@@ -22,12 +26,16 @@ use crate::config::{BridgeConfig, TrustMode};
 /// MCP bridge 全体の state。
 pub struct UnisonBridge {
     config: BridgeConfig,
-    /// 起動時に config.endpoint に対して fetch した DynamicProtocol。
-    /// None = endpoint 未設定 or 接続失敗 (= synthesized tools 不可、 static のみ)。
-    discovered: Option<DiscoveredProtocol>,
+    /// 現在 active な discovery 結果。 起動時に config.endpoint から fetch し、
+    /// 以後 `unison_discover` (= default endpoint 宛) が refresh する。
+    /// None = endpoint 未設定 or 未 discovery (= synthesized tools 不可、 static のみ)。
+    ///
+    /// lock は read → Arc clone → 即 drop の短い critical section のみ
+    /// (= await を跨いで保持しない) なので std の RwLock で足りる。
+    discovered: RwLock<Option<Arc<DiscoveredProtocol>>>,
 }
 
-/// 起動時 discovery 結果
+/// discovery 結果 (= 起動時 or `unison_discover` による refresh)
 pub struct DiscoveredProtocol {
     pub proto: Arc<DynamicProtocol>,
 }
@@ -70,12 +78,29 @@ impl UnisonBridge {
                 None
             }
         };
-        Ok(Self { config, discovered })
+        Ok(Self {
+            config,
+            discovered: RwLock::new(discovered.map(Arc::new)),
+        })
     }
 
-    /// Discovered protocol への参照 (= synthesized tools 用)
-    pub fn discovered(&self) -> Option<&DiscoveredProtocol> {
-        self.discovered.as_ref()
+    /// 現在の discovered protocol (= synthesized tools 用)。 Arc clone を返すので
+    /// 呼び出し側は lock を保持せず自由に使える。
+    pub fn discovered(&self) -> Option<Arc<DiscoveredProtocol>> {
+        self.discovered
+            .read()
+            .expect("discovered lock poisoned")
+            .clone()
+    }
+
+    /// discovery を新しい結果で置き換え、 **直前の** protocol hash を返す
+    /// (= 呼び出し側が hash 比較で「tool set が実際に変わったか」を判定し、
+    /// `tools/list_changed` 通知を hash 変化時に限定できる)。
+    pub fn set_discovered(&self, d: DiscoveredProtocol) -> Option<String> {
+        let mut guard = self.discovered.write().expect("discovered lock poisoned");
+        let old_hash = guard.as_ref().map(|p| p.proto.hash().to_string());
+        *guard = Some(Arc::new(d));
+        old_hash
     }
 
     /// Tool arg で endpoint が未指定の場合、 config の default endpoint を返す。
@@ -197,7 +222,7 @@ mod tests {
                 endpoint: Some("default".to_string()),
                 trust: None,
             },
-            discovered: None,
+            discovered: RwLock::new(None),
         };
         assert_eq!(bridge.resolve_endpoint(Some("override")), Some("override"));
         assert_eq!(bridge.resolve_endpoint(None), Some("default"));
@@ -207,7 +232,7 @@ mod tests {
     fn endpoint_resolution_empty_returns_none() {
         let bridge = UnisonBridge {
             config: BridgeConfig::default(),
-            discovered: None,
+            discovered: RwLock::new(None),
         };
         assert_eq!(bridge.resolve_endpoint(None), None);
     }
@@ -219,7 +244,7 @@ mod tests {
                 endpoint: None,
                 trust: Some(TrustMode::System),
             },
-            discovered: None,
+            discovered: RwLock::new(None),
         };
         // arg / config の明示は endpoint に関係なく優先される
         assert_eq!(
@@ -236,7 +261,7 @@ mod tests {
     fn trust_default_is_skip_for_loopback() {
         let bridge = UnisonBridge {
             config: BridgeConfig::default(),
-            discovered: None,
+            discovered: RwLock::new(None),
         };
         // 明示なし + loopback → Skip (dev ergonomics)
         assert_eq!(
@@ -257,7 +282,7 @@ mod tests {
     fn trust_default_is_system_for_remote() {
         let bridge = UnisonBridge {
             config: BridgeConfig::default(),
-            discovered: None,
+            discovered: RwLock::new(None),
         };
         // 明示なし + remote → System (secure-by-default、 silent skip を防ぐ)
         assert_eq!(

--- a/crates/unison-mcp/src/mapping.rs
+++ b/crates/unison-mcp/src/mapping.rs
@@ -91,9 +91,12 @@ fn sanitize_description(s: &str) -> String {
 /// `ChannelRequest` を MCP `Tool` に変換する。
 ///
 /// - name: `synth_tool_name(channel, request.name)`
+/// - title: `channel.method` (= sanitize 前の人間可読表示名、 制御文字のみ除去)
 /// - description: KDL `request "X" description="..."` があればその文字列を採用、
 ///   無ければ formulaic な default (= 「Invoke the X request on the Y channel」) を生成
 /// - input_schema: `request.fields` を JSON Schema object に変換
+/// - output_schema: KDL `returns` block があれば同じ converter で合成
+///   (= tool が入出力とも typed になり、 client は `structuredContent` を検証できる)
 ///
 /// description は LLM の tool-selection accuracy に強相関するので、 schema 設計時に
 /// `description="..."` を書くことで LLM が tool を正しく選びやすくなる。
@@ -109,16 +112,23 @@ pub fn synthesize_tool(channel_name: &str, request: &ChannelRequest) -> Tool {
                 request.name, channel_name
             )
         });
-    let input_schema = fields_to_input_schema(&request.fields);
-    Tool::new(
+    let input_schema = fields_to_object_schema(&request.fields);
+    let title = sanitize_description(&format!("{}.{}", channel_name, request.name));
+    let mut tool = Tool::new(
         Cow::Owned(name),
         Cow::Owned(description),
         Arc::new(input_schema),
     )
+    .with_title(title);
+    if let Some(returns) = &request.returns {
+        tool = tool.with_raw_output_schema(Arc::new(fields_to_object_schema(&returns.fields)));
+    }
+    tool
 }
 
-/// `Field` 群から JSON Schema object (= top-level `{type: "object", properties: {...}, required: [...]}`) を組み立てる
-pub fn fields_to_input_schema(fields: &[Field]) -> JsonObject {
+/// `Field` 群から JSON Schema object (= top-level `{type: "object", properties: {...}, required: [...]}`) を組み立てる。
+/// `Tool.input_schema` (= request.fields) と `Tool.output_schema` (= returns.fields) の両方に使う。
+pub fn fields_to_object_schema(fields: &[Field]) -> JsonObject {
     let mut properties = Map::new();
     let mut required = Vec::new();
     for f in fields {
@@ -334,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn fields_to_input_schema_basic() {
+    fn fields_to_object_schema_basic() {
         // Mock: 既存 schemas/ping_pong.kdl と類似の構造を 直接 Field で組まずに、
         // 既存 KDL parser 経由で取得する
         let kdl = r#"
@@ -350,7 +360,7 @@ protocol "x" version="0.1.0" {
 "#;
         let parsed = unison::parser::SchemaParser::new().parse(kdl).unwrap();
         let req = &parsed.protocol.as_ref().unwrap().channels[0].requests[0];
-        let schema = fields_to_input_schema(&req.fields);
+        let schema = fields_to_object_schema(&req.fields);
 
         assert_eq!(schema.get("type"), Some(&json!("object")));
         let props = schema.get("properties").and_then(Value::as_object).unwrap();
@@ -502,6 +512,83 @@ protocol "x" version="0.1.0" {
         assert!(meta.get("additionalProperties").is_some());
     }
 
+    /// KDL `returns` block → `Tool.output_schema` 合成 (= rmcp 2.x / MCP 2025-06-18)。
+    /// input と同じ converter を通るので、 型対応・required・additionalProperties の
+    /// 挙動は input_schema と完全に一致する。
+    #[test]
+    fn synthesize_tool_with_returns_produces_output_schema() {
+        let kdl = r#"
+protocol "x" version="0.1.0" {
+    channel "chat" from="client" lifetime="persistent" {
+        request "Send" {
+            field "msg" type="string" required=#true
+            returns "Sent" {
+                field "id" type="string" required=#true
+                field "ts" type="int"
+            }
+        }
+    }
+}
+"#;
+        let parsed = unison::parser::SchemaParser::new().parse(kdl).unwrap();
+        let req = &parsed.protocol.as_ref().unwrap().channels[0].requests[0];
+        let tool = synthesize_tool("chat", req);
+
+        let out = tool
+            .output_schema
+            .as_ref()
+            .expect("returns block must produce output_schema");
+        assert_eq!(out.get("type"), Some(&json!("object")));
+        let props = out.get("properties").and_then(Value::as_object).unwrap();
+        assert_eq!(
+            props
+                .get("id")
+                .and_then(Value::as_object)
+                .unwrap()
+                .get("type"),
+            Some(&json!("string"))
+        );
+        assert_eq!(
+            props
+                .get("ts")
+                .and_then(Value::as_object)
+                .unwrap()
+                .get("type"),
+            Some(&json!("integer"))
+        );
+        let required = out.get("required").and_then(Value::as_array).unwrap();
+        assert_eq!(required, &vec![json!("id")]);
+    }
+
+    /// returns block が無い request は output_schema を宣言しない (= 出力は自由形)。
+    #[test]
+    fn synthesize_tool_without_returns_has_no_output_schema() {
+        let req = ChannelRequest {
+            name: "Fire".to_string(),
+            description: None,
+            fields: vec![],
+            returns: None,
+        };
+        let tool = synthesize_tool("events", &req);
+        assert!(tool.output_schema.is_none());
+    }
+
+    /// title は sanitize 前の `channel.method` (= 人間可読表示名)。
+    /// name の `[A-Za-z0-9_]` 正規化で失われる dot 等の情報を title が保持する。
+    #[test]
+    fn synthesize_tool_title_is_human_readable_channel_dot_method() {
+        let req = ChannelRequest {
+            name: "GetProtocol".to_string(),
+            description: None,
+            fields: vec![],
+            returns: None,
+        };
+        let tool = synthesize_tool("unison.discovery", &req);
+        assert_eq!(tool.title.as_deref(), Some("unison.discovery.GetProtocol"));
+        // name 側は従来どおり正規化される
+        assert_eq!(tool.name.as_ref(), "unison_unison_discovery_GetProtocol");
+    }
+
     /// Anthropic Messages API `tools[].input_schema` 互換性: top-level に
     /// `type: "object"` + `properties` がある JSON Schema Draft 7+ object であること
     /// が要求される。 本 test で構造を検証 (= Hailing-δ leverage 1 acceptance)。
@@ -518,7 +605,7 @@ protocol "x" version="0.1.0" {
 "#;
         let parsed = unison::parser::SchemaParser::new().parse(kdl).unwrap();
         let req = &parsed.protocol.as_ref().unwrap().channels[0].requests[0];
-        let schema = fields_to_input_schema(&req.fields);
+        let schema = fields_to_object_schema(&req.fields);
 
         // Anthropic input_schema 要件:
         // 1. top-level type は "object"

--- a/crates/unison-mcp/src/tools.rs
+++ b/crates/unison-mcp/src/tools.rs
@@ -22,7 +22,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use rmcp::{
-    ErrorData as McpError, RoleServer, ServerHandler,
+    ErrorData as McpError, Peer, RoleServer, ServerHandler,
     handler::server::{common::schema_for_type, wrapper::Parameters},
     model::*,
     service::RequestContext,
@@ -51,6 +51,10 @@ pub struct UnisonMcp {
 
 impl UnisonMcp {
     pub fn new(bridge: UnisonBridge) -> Self {
+        // annotations: endpoint が任意指定できる = 外部世界に開いている (open_world)。
+        // ping / discover は server 状態を変えない (read_only + idempotent)。
+        // call は任意 payload を送る escape hatch なので hint なし (= client は
+        // spec default の「destructive かもしれない」扱いで確認を挟める)。
         let static_tools = vec![
             Tool::new(
                 Cow::Borrowed("unison_ping"),
@@ -58,6 +62,12 @@ impl UnisonMcp {
                     "Verify connectivity to a Unison server. Connects then disconnects, returning a success message.",
                 ),
                 schema_for_type::<PingArgs>(),
+            )
+            .annotate(
+                ToolAnnotations::new()
+                    .read_only(true)
+                    .idempotent(true)
+                    .open_world(true),
             ),
             Tool::new(
                 Cow::Borrowed("unison_call"),
@@ -65,13 +75,20 @@ impl UnisonMcp {
                     "Generic escape hatch: open any channel on a Unison server, send a typed method+payload, return the response. No schema validation.",
                 ),
                 schema_for_type::<CallArgs>(),
-            ),
+            )
+            .annotate(ToolAnnotations::new().open_world(true)),
             Tool::new(
                 Cow::Borrowed("unison_discover"),
                 Cow::Borrowed(
-                    "Fetch the protocol KDL from a Unison server via the `unison.discovery` channel. Returns channel/request listing + version/hash/codecs.",
+                    "Fetch the protocol KDL from a Unison server via the `unison.discovery` channel. Returns channel/request listing + version/hash/codecs. When targeting the configured default endpoint, refreshes the synthesized tool set (emits tools/list_changed on schema change).",
                 ),
                 schema_for_type::<DiscoverArgs>(),
+            )
+            .annotate(
+                ToolAnnotations::new()
+                    .read_only(true)
+                    .idempotent(true)
+                    .open_world(true),
             ),
         ];
         Self {
@@ -130,25 +147,37 @@ impl UnisonMcp {
         tools
     }
 
-    /// MCP transport context を要らない tool dispatch (= ServerHandler::call_tool の
-    /// 本体、 integration test からも直接呼べる)。
+    /// MCP transport context を要らない tool dispatch (= integration test からも
+    /// 直接呼べる)。 peer 無し = elicitation / list_changed 通知はスキップされる。
     pub async fn invoke_tool(
         &self,
         name: &str,
         args: serde_json::Value,
     ) -> Result<CallToolResult, McpError> {
+        self.invoke_tool_with_peer(name, args, None).await
+    }
+
+    /// peer 付き tool dispatch (= ServerHandler::call_tool の本体)。 peer は
+    /// endpoint 未設定時の elicitation と、 discovery refresh 時の
+    /// `tools/list_changed` 通知に使う。
+    pub async fn invoke_tool_with_peer(
+        &self,
+        name: &str,
+        args: serde_json::Value,
+        peer: Option<&Peer<RoleServer>>,
+    ) -> Result<CallToolResult, McpError> {
         match name {
             "unison_ping" => {
                 let Parameters(args) = parse_params::<PingArgs>(args)?;
-                handle_ping(&self.bridge, args).await
+                handle_ping(&self.bridge, args, peer).await
             }
             "unison_call" => {
                 let Parameters(args) = parse_params::<CallArgs>(args)?;
-                handle_call(&self.bridge, args).await
+                handle_call(&self.bridge, args, peer).await
             }
             "unison_discover" => {
                 let Parameters(args) = parse_params::<DiscoverArgs>(args)?;
-                handle_discover(&self.bridge, args).await
+                handle_discover(&self.bridge, args, peer).await
             }
             other => handle_synthesized(&self.bridge, other, args).await,
         }
@@ -160,7 +189,7 @@ impl UnisonMcp {
             return Some(t.clone());
         }
         let disc = self.bridge.discovered()?;
-        let (channel_name, method) = resolve_synth_tool(disc, name)?;
+        let (channel_name, method) = resolve_synth_tool(&disc, name)?;
         let request = disc
             .proto
             .registry()
@@ -222,22 +251,67 @@ pub struct DiscoverArgs {
 // Handler impls (= 各 tool の本体)
 // ---------------------------------------------------------------------------
 
+/// endpoint 未設定時に client へ質問する elicitation の回答 schema。
+/// MCP elicitation は flat な primitive object のみ許可 (= `ElicitationSafe`)。
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EndpointAnswer {
+    /// Unison server endpoint URL (= 例: `quic://[::1]:7878`)
+    endpoint: String,
+}
+rmcp::elicit_safe!(EndpointAnswer);
+
+/// client に endpoint をその場で質問する (= MCP elicitation)。
+/// client が elicitation 非対応 / 拒否 / cancel / 失敗は None を返し、
+/// 呼び出し側は従来どおり invalid_request エラーへ fallback する。
+async fn elicit_endpoint(peer: Option<&Peer<RoleServer>>) -> Option<String> {
+    let peer = peer?;
+    let supports = peer
+        .peer_info()
+        .is_some_and(|info| info.capabilities.elicitation.is_some());
+    if !supports {
+        return None;
+    }
+    match peer
+        .elicit::<EndpointAnswer>(
+            "No Unison endpoint is configured. Enter the server endpoint URL (e.g. quic://[::1]:7878).",
+        )
+        .await
+    {
+        Ok(Some(ans)) => {
+            let endpoint = ans.endpoint.trim().to_string();
+            if endpoint.is_empty() { None } else { Some(endpoint) }
+        }
+        // decline / cancel はユーザーの意思 = そのままエラー路線へ
+        Ok(None) => None,
+        Err(e) => {
+            tracing::debug!(error = %e, "endpoint elicitation failed; falling back to error");
+            None
+        }
+    }
+}
+
 /// 共通: endpoint を resolve + ProtocolClient を build + connect する。
+/// endpoint が arg にも config にも無い場合、 elicitation 対応 client には
+/// その場で質問する (= [`elicit_endpoint`])。
 async fn connect_client(
     bridge: &UnisonBridge,
     endpoint_arg: Option<&str>,
     trust_arg: Option<TrustMode>,
+    peer: Option<&Peer<RoleServer>>,
 ) -> Result<(unison::ProtocolClient, String), McpError> {
     use unison::ProtocolClient;
     use unison::network::quic::QuicClient;
 
-    let endpoint = bridge.resolve_endpoint(endpoint_arg).ok_or_else(|| {
-        McpError::invalid_request(
-            "endpoint not provided and no default in BridgeConfig".to_string(),
-            None,
-        )
-    })?;
-    let trust = bridge.resolve_trust(trust_arg, endpoint);
+    let endpoint: String = match bridge.resolve_endpoint(endpoint_arg) {
+        Some(e) => e.to_string(),
+        None => elicit_endpoint(peer).await.ok_or_else(|| {
+            McpError::invalid_request(
+                "endpoint not provided and no default in BridgeConfig".to_string(),
+                None,
+            )
+        })?,
+    };
+    let trust = bridge.resolve_trust(trust_arg, &endpoint);
 
     let quic = QuicClient::builder()
         .trust_anchors(trust.to_anchors())
@@ -246,22 +320,35 @@ async fn connect_client(
     let client = ProtocolClient::new(quic);
 
     client
-        .connect(endpoint)
+        .connect(&endpoint)
         .await
         .map_err(|e| McpError::internal_error(format!("connect failed: {e}"), None))?;
 
-    Ok((client, endpoint.to_string()))
+    Ok((client, endpoint))
 }
 
-async fn handle_ping(bridge: &UnisonBridge, args: PingArgs) -> Result<CallToolResult, McpError> {
-    let (_client, endpoint) = connect_client(bridge, args.endpoint.as_deref(), args.trust).await?;
+async fn handle_ping(
+    bridge: &UnisonBridge,
+    args: PingArgs,
+    peer: Option<&Peer<RoleServer>>,
+) -> Result<CallToolResult, McpError> {
+    let (_client, endpoint) =
+        connect_client(bridge, args.endpoint.as_deref(), args.trust, peer).await?;
     let trust = bridge.resolve_trust(args.trust, &endpoint);
-    let msg = format!("✅ connected to {endpoint} (trust={trust:?})");
-    Ok(CallToolResult::success(vec![ContentBlock::text(msg)]))
+    Ok(CallToolResult::structured(serde_json::json!({
+        "connected": true,
+        "endpoint": endpoint,
+        "trust": format!("{trust:?}").to_lowercase(),
+    })))
 }
 
-async fn handle_call(bridge: &UnisonBridge, args: CallArgs) -> Result<CallToolResult, McpError> {
-    let (client, _endpoint) = connect_client(bridge, args.endpoint.as_deref(), args.trust).await?;
+async fn handle_call(
+    bridge: &UnisonBridge,
+    args: CallArgs,
+    peer: Option<&Peer<RoleServer>>,
+) -> Result<CallToolResult, McpError> {
+    let (client, _endpoint) =
+        connect_client(bridge, args.endpoint.as_deref(), args.trust, peer).await?;
 
     let channel = client
         .open_channel(&args.channel_name)
@@ -273,23 +360,24 @@ async fn handle_call(bridge: &UnisonBridge, args: CallArgs) -> Result<CallToolRe
         .await
         .map_err(|e| McpError::internal_error(format!("request failed: {e}"), None))?;
 
-    let result = serde_json::json!({
+    // escape hatch は output_schema を宣言しないので、 channel/method 込みの
+    // wrapper object を structured で返す (= 常に object になる)。
+    Ok(CallToolResult::structured(serde_json::json!({
         "channel": args.channel_name,
         "method": args.method,
         "response": response,
-    });
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        result.to_string(),
-    )]))
+    })))
 }
 
 async fn handle_discover(
     bridge: &UnisonBridge,
     args: DiscoverArgs,
+    peer: Option<&Peer<RoleServer>>,
 ) -> Result<CallToolResult, McpError> {
     use unison::network::DynamicProtocol;
 
-    let (client, endpoint) = connect_client(bridge, args.endpoint.as_deref(), args.trust).await?;
+    let (client, endpoint) =
+        connect_client(bridge, args.endpoint.as_deref(), args.trust, peer).await?;
     let client = Arc::new(client);
 
     let proto = DynamicProtocol::fetch(client.clone())
@@ -313,19 +401,37 @@ async fn handle_discover(
         })
         .collect();
 
-    let summary = serde_json::json!({
+    let hash = proto.hash().to_string();
+    let mut summary = serde_json::json!({
         "endpoint": endpoint,
         "protocol_name": proto.protocol_name(),
         "version": proto.version(),
         "namespace": proto.registry().protocol_namespace(),
-        "hash": proto.hash(),
+        "hash": hash,
         "codecs": proto.codecs(),
         "channels": channels,
+        "refreshed": false,
     });
 
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        serde_json::to_string_pretty(&summary).unwrap_or_else(|_| summary.to_string()),
-    )]))
+    // default endpoint への discover は bridge の discovery を refresh する
+    // (= server の schema 進化に MCP session 中に追従する live bridge)。
+    // 明示的に別 endpoint を指定した discover は one-off 照会で state を触らない。
+    if bridge.resolve_endpoint(None) == Some(endpoint.as_str()) {
+        let old_hash = bridge.set_discovered(DiscoveredProtocol {
+            proto: Arc::new(proto),
+        });
+        summary["refreshed"] = serde_json::Value::Bool(true);
+        if old_hash.as_deref() != Some(hash.as_str()) {
+            tracing::info!(hash = %hash, "protocol schema changed — synthesized tool set refreshed");
+            if let Some(peer) = peer
+                && let Err(e) = peer.notify_tool_list_changed().await
+            {
+                tracing::warn!(error = %e, "tools/list_changed notification failed");
+            }
+        }
+    }
+
+    Ok(CallToolResult::structured(summary))
 }
 
 /// Synthesized typed tool の dispatch。 bridge.discovered() の DynamicProtocol 経由で
@@ -362,7 +468,7 @@ async fn handle_synthesized(
         )
     })?;
 
-    let (channel_name, method) = resolve_synth_tool(disc, tool_name)
+    let (channel_name, method) = resolve_synth_tool(&disc, tool_name)
         .ok_or(McpError::method_not_found::<CallToolRequestMethod>())?;
 
     let chan = disc
@@ -383,14 +489,16 @@ async fn handle_synthesized(
         }
     })?;
 
-    let result = serde_json::json!({
-        "channel": channel_name,
-        "method": method,
-        "response": response,
-    });
-    Ok(CallToolResult::success(vec![ContentBlock::text(
-        serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()),
-    )]))
+    // structured_content は response そのもの (= KDL `returns` から合成した
+    // output_schema と形が一致する)。 channel/method は tool 名が既に示している。
+    // returns 未定義 channel の非 object response のみ wrapper で object 化する
+    // (= MCP spec: structuredContent は object)。
+    let structured = if response.is_object() {
+        response
+    } else {
+        serde_json::json!({ "response": response })
+    };
+    Ok(CallToolResult::structured(structured))
 }
 
 // ---------------------------------------------------------------------------
@@ -399,13 +507,22 @@ async fn handle_synthesized(
 
 impl ServerHandler for UnisonMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_tool_list_changed()
+                .build(),
+        )
+        .with_instructions(
             "MCP bridge for Unison Protocol. Static escape hatch tools: \
                  `unison_ping` / `unison_call` / `unison_discover`. \
                  If a default endpoint is configured (= unison.json), synthesized typed tools \
                  named `unison_<channel>_<method>` are also exposed for each channel.request \
                  in the discovered KDL schema. Synthesized tools are payload-validated against \
-                 the server's schema before dispatch (= fail-fast on type mismatch).",
+                 the server's schema before dispatch (= fail-fast on type mismatch), declare \
+                 output_schema from the KDL `returns` block, and return results as \
+                 structuredContent (text mirror included). Calling `unison_discover` against \
+                 the default endpoint refreshes the synthesized tool set (tools/list_changed).",
         )
     }
 
@@ -431,10 +548,13 @@ impl ServerHandler for UnisonMcp {
     fn call_tool(
         &self,
         request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> impl std::future::Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
         let args_value = serde_json::Value::Object(request.arguments.clone().unwrap_or_default());
-        async move { self.invoke_tool(request.name.as_ref(), args_value).await }
+        async move {
+            self.invoke_tool_with_peer(request.name.as_ref(), args_value, Some(&context.peer))
+                .await
+        }
     }
 }
 
@@ -474,6 +594,28 @@ mod tests {
         let server = UnisonMcp::new(bridge);
         let tools = server.all_tools();
         assert_eq!(tools.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn static_tools_have_annotations() {
+        let bridge = UnisonBridge::new(BridgeConfig::default()).await.unwrap();
+        let server = UnisonMcp::new(bridge);
+
+        let ping = server.find_tool("unison_ping").unwrap();
+        let ann = ping.annotations.expect("ping annotations");
+        assert_eq!(ann.read_only_hint, Some(true));
+        assert_eq!(ann.idempotent_hint, Some(true));
+        assert_eq!(ann.open_world_hint, Some(true));
+
+        let discover = server.find_tool("unison_discover").unwrap();
+        let ann = discover.annotations.expect("discover annotations");
+        assert_eq!(ann.read_only_hint, Some(true));
+
+        // call は escape hatch = read_only/destructive を主張しない (spec default 扱い)
+        let call = server.find_tool("unison_call").unwrap();
+        let ann = call.annotations.expect("call annotations");
+        assert_eq!(ann.read_only_hint, None);
+        assert_eq!(ann.open_world_hint, Some(true));
     }
 
     #[tokio::test]

--- a/crates/unison-mcp/tests/test_integ_synthesis.rs
+++ b/crates/unison-mcp/tests/test_integ_synthesis.rs
@@ -95,6 +95,81 @@ async fn start_test_server() -> Result<(ServerHandle, String)> {
     Ok((handle, format!("[{}]:{}", addr.ip(), addr.port())))
 }
 
+/// refresh E2E 用の「進化した」schema — 別 channel / 別 request / 別 version
+/// (= TEST_KDL と protocol hash が必ず異なる)
+const TEST_KDL_V2: &str = r#"
+protocol "test-synth" version="0.43.0" {
+    namespace "test.synth.e2e"
+
+    channel "unison.discovery" from="client" lifetime="persistent" {
+        request "GetProtocol" {
+            field "format" type="string" required=#true
+            returns "ProtocolDocument" {
+                field "kdl" type="string" required=#true
+                field "version" type="string" required=#true
+                field "hash" type="string" required=#true
+                field "codecs" type="json" required=#true
+            }
+        }
+    }
+
+    channel "test.probe" from="client" lifetime="persistent" {
+        request "Probe" {
+            field "q" type="string" required=#true
+            returns "Ack" {
+                field "ack" type="string" required=#true
+            }
+        }
+    }
+}
+"#;
+
+/// 指定 addr に TEST_KDL_V2 の server を起動する (= schema 進化後の server を模擬)。
+/// `spawn_listen` は self を consume するため、 bind retry は server ごと作り直す
+/// (= 直前の server の UDP socket close 直後は bind が失敗し得る)。
+async fn start_test_server_v2(addr: &str) -> Result<ServerHandle> {
+    let mut last_err: Option<anyhow::Error> = None;
+    for _ in 0..10 {
+        let server = ProtocolServer::with_identity("test-synth-srv2", "0.43.0", "test");
+        server.enable_discovery(TEST_KDL_V2).await?;
+        server
+            .register_channel("test.probe", |_ctx, stream| async move {
+                let channel = UnisonChannel::new(stream);
+                loop {
+                    match channel.recv().await {
+                        Ok(msg)
+                            if msg.msg_type == MessageType::Request && msg.method == "Probe" =>
+                        {
+                            let payload = msg.payload_as_value().unwrap_or_default();
+                            let q = payload.get("q").and_then(|v| v.as_str()).unwrap_or("");
+                            let reply = json!({ "ack": format!("ack: {q}") });
+                            if channel
+                                .send_response(msg.id, &msg.method, &reply)
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Ok(_) => continue,
+                        Err(e) if e.is_normal_close() => return Ok(()),
+                        Err(e) => return Err(e),
+                    }
+                }
+                Ok(())
+            })
+            .await;
+        match server.spawn_listen(addr).await {
+            Ok(h) => return Ok(h),
+            Err(e) => {
+                last_err = Some(e.into());
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    Err(last_err.expect("at least one bind attempt"))
+}
+
 /// 接続済 server + UnisonMcp を組み立てて返す
 async fn start_mcp_with_endpoint(endpoint: &str) -> Result<UnisonMcp> {
     let config = BridgeConfig {
@@ -157,6 +232,30 @@ async fn test_e2e_synthesis_lists_static_plus_synthesized_tools() -> Result<()> 
         .and_then(Value::as_array)
         .expect("required present");
     assert!(required.contains(&json!("msg")));
+
+    // title は人間可読な channel.method (= rmcp 2.x)
+    assert_eq!(echo_tool.title.as_deref(), Some("test.echo.Ping"));
+
+    // KDL `returns` block から output_schema が合成される (= rmcp 2.x)
+    let out_schema: Value = serde_json::to_value(
+        echo_tool
+            .output_schema
+            .as_ref()
+            .expect("returns block must produce output_schema")
+            .as_ref(),
+    )?;
+    assert_eq!(out_schema.get("type"), Some(&json!("object")));
+    let out_props = out_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("output properties");
+    assert!(out_props.contains_key("reply"));
+    assert!(out_props.contains_key("count"));
+    let out_required = out_schema
+        .get("required")
+        .and_then(Value::as_array)
+        .expect("output required");
+    assert!(out_required.contains(&json!("reply")));
     info!(
         "synthesized {} tools total ({} synthesized + 3 static)",
         tools.len(),
@@ -185,7 +284,18 @@ async fn test_e2e_synthesis_invoke_synthesized_tool_round_trip() -> Result<()> {
     )
     .await??;
 
-    // CallToolResult の content[0] が text、 JSON parse して中身を assert
+    // structured_content = response そのもの (= output_schema と同形、 rmcp 2.x)
+    let resp = result
+        .structured_content
+        .as_ref()
+        .expect("structured content present");
+    assert_eq!(
+        resp.get("reply").and_then(Value::as_str),
+        Some("Pong: hello")
+    );
+    assert_eq!(resp.get("count").and_then(Value::as_i64), Some(1));
+
+    // text content は structured の互換 mirror (= 同じ JSON にパースできる)
     let content_text = match result.content.first() {
         Some(c) => match c {
             rmcp::model::ContentBlock::Text(t) => t.text.clone(),
@@ -194,12 +304,7 @@ async fn test_e2e_synthesis_invoke_synthesized_tool_round_trip() -> Result<()> {
         None => panic!("no content in CallToolResult"),
     };
     let parsed: Value = serde_json::from_str(&content_text)?;
-    let resp = parsed.get("response").expect("response field");
-    assert_eq!(
-        resp.get("reply").and_then(Value::as_str),
-        Some("Pong: hello")
-    );
-    assert_eq!(resp.get("count").and_then(Value::as_i64), Some(1));
+    assert_eq!(&parsed, resp, "text mirror must match structured content");
 
     handle.shutdown().await?;
     Ok(())
@@ -272,5 +377,68 @@ async fn test_e2e_synthesis_find_tool_finds_synthesized() -> Result<()> {
     assert!(mcp.find_tool("ghost_tool").is_none());
 
     handle.shutdown().await?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Test 5: default endpoint への unison_discover が synthesized tool set を
+// refresh する (= live bridge、 server の schema 進化に session 中に追従)
+// ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "Large: E2E test"]
+async fn test_e2e_discover_refreshes_synthesized_tools() -> Result<()> {
+    init_tracing();
+    let (h1, addr) = start_test_server().await?;
+    let mcp = start_mcp_with_endpoint(&addr).await?;
+
+    let ping_tool = mapping::synth_tool_name("test.echo", "Ping");
+    let probe_tool = mapping::synth_tool_name("test.probe", "Probe");
+    let names: Vec<String> = mcp.all_tools().iter().map(|t| t.name.to_string()).collect();
+    assert!(names.contains(&ping_tool), "v1 tool present: {names:?}");
+    assert!(!names.contains(&probe_tool), "v2 tool absent: {names:?}");
+
+    // server の schema 進化を模擬: 同一 endpoint で異なる KDL の server に入れ替える
+    h1.shutdown().await?;
+    let h2 = start_test_server_v2(&addr).await?;
+
+    // default endpoint (= endpoint arg 省略) への discover が refresh を起こす
+    let result = timeout(
+        Duration::from_secs(10),
+        mcp.invoke_tool("unison_discover", json!({})),
+    )
+    .await??;
+    let sc = result
+        .structured_content
+        .as_ref()
+        .expect("structured content");
+    assert_eq!(sc.get("refreshed"), Some(&json!(true)));
+    assert_eq!(
+        sc.get("version").and_then(Value::as_str),
+        Some("0.43.0"),
+        "summary must reflect the new server schema"
+    );
+
+    // synthesized tool set が新 schema に入れ替わっている
+    let names: Vec<String> = mcp.all_tools().iter().map(|t| t.name.to_string()).collect();
+    assert!(
+        names.contains(&probe_tool),
+        "new schema tool must appear: {names:?}"
+    );
+    assert!(
+        !names.contains(&ping_tool),
+        "old schema tool must disappear: {names:?}"
+    );
+
+    // 入れ替わった tool が実際に dispatch できる (= 新 connection 経由の round-trip)
+    let result = timeout(
+        Duration::from_secs(5),
+        mcp.invoke_tool(&probe_tool, json!({ "q": "hello" })),
+    )
+    .await??;
+    let sc = result.structured_content.expect("probe structured");
+    assert_eq!(sc.get("ack").and_then(Value::as_str), Some("ack: hello"));
+
+    h2.shutdown().await?;
     Ok(())
 }


### PR DESCRIPTION
## 概要
rmcp 1.7→2.2 更新（#88）後の深掘り調査で見つかった MCP spec 2025-06-18+ 世代の機能を unison-mcp に還元する。KDL がスキーマ SSOT である Unison の設計と MCP の進化方向が一致しており、大半は**既にある情報の配線**で実現できた。

## P1 — typed I/O（半日枠の低コスト・高価値）

### ① KDL `returns` → `Tool.output_schema` 合成
`fields_to_input_schema` を `fields_to_object_schema` に rename し、`returns.fields` にも適用。synthesized tools が**入出力とも typed** になり、client は `structuredContent` を output_schema で検証できる。型対応・required・additionalProperties の挙動は input と完全一致。

### ② 全 tool 結果を `structuredContent` 化
`CallToolResult::structured()`（text mirror 自動併記 = 後方互換）に置換。synthesized tools は **response そのもの**を structured で返し、①の output_schema と形が一致する。`unison_call`（escape hatch、schema なし）のみ `{channel, method, response}` wrapper を維持。

### ③ ToolAnnotations + title
- `unison_ping` / `unison_discover` = read-only + idempotent + open-world
- `unison_call` = open-world のみ（escape hatch は destructive 可能性を spec default に委ねる）
- synthesized tools に `title`（= sanitize 前の `channel.method` 人間可読表示名。name の `[A-Za-z0-9_]` 正規化で失われる dot 情報を保持）

## P2 — live bridge 化

### ④ live re-discovery + `tools/list_changed`
`UnisonBridge.discovered` を `RwLock<Option<Arc<DiscoveredProtocol>>>` 化（read → Arc clone → 即 drop、await 跨ぎなし）。**default endpoint への `unison_discover` 成功時に discovery を置き換え**、synthesized tool set が MCP session 中に更新される（= server の schema 進化に追従する live bridge）。protocol hash 変化時のみ `notifications/tools/list_changed` を発行（`listChanged` capability 宣言済み）。別 endpoint への discover は one-off 照会で state を触らない（response の `refreshed` field で判別可）。

### ⑤ endpoint elicitation
endpoint が config にも tool arg にも無い場合、elicitation 対応 client には `Peer::elicit` で**その場で接続先を質問**（rmcp feature `elicitation` + `schemars` 追加、`elicit_safe!` で flat object 制約準拠）。capability 未宣言 / 拒否 / cancel / 失敗は従来どおり invalid_request エラーへ graceful fallback。

## 検証
- unit **41 passed**（新規 5: output_schema 合成 ×2 / title / annotations）
- E2E **5 passed** — 新規 refresh E2E は「server 入れ替え（同一 endpoint・別 KDL）→ discover → tool set 入れ替わり → 新 tool round-trip」まで実証
- `cargo test --workspace` 全 green / `clippy --lib --workspace -- -D warnings` クリーン / fmt クリーン
- README（Status 表 / discover refresh semantics / Tools 共通挙動）+ CHANGELOG 同期済み

## 調査メモ
rmcp 2.x 残りの発見（Tasks = 非同期 tool 実行 2026-07-28 spec、streamable HTTP transport、KDL への MCP hint 逆輸入）は P3 としてウォッチ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxnrvNjvkqy3MPhciMJwVh
