### PR TITLE
chore(release): 1.7.0 — unison-mcp rmcp 2 系 + live MCP bridge 化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-14 — unison-mcp: rmcp 2 系 + live MCP bridge 化
+
+> unison-mcp を MCP spec 2025-06-18+ 世代へ引き上げるリリース。KDL `returns` からの
+> `output_schema` 合成・`structuredContent`・live re-discovery・elicitation（#88/#91/#92、
+> team-b Moody Blues ディープレビュー済み）に加え、QUIC accept loop の片肺死修正（#90）と
+> Edge(nightly) への CI ゲート整備（#89）を含む。SemVer minor（additive、既存 API 不変）。
+
 ### Added
 
 - **unison-mcp: rmcp 2 系機能の還元 — typed I/O + live bridge 化**:
@@ -40,6 +47,17 @@
 
   いずれも `unison-mcp`（`publish = false` の MCP bridge crate）内に閉じ、公開 `club-unison` API への
   影響はなし。
+- **unison-mcp: tool description / arg schema / エラーの全面 UX 整備**: description の stale 解消
+  （ping の "success message"、trust default の実挙動）、arg schema doc の英語統一（schemars 経由で
+  LLM に露出するため）、actionable エラー（文脈 + 次のアクション提示）、instructions の再構成、
+  static tools への title 付与。Moody Blues review 指摘の解消（`fields_to_object_schema` の
+  field 数 cap + hostile field 名 skip + description sanitize、テスト空白の充填 = unit 45 / E2E 7）。
+
+### Fixed
+
+- **QUIC accept loop の片肺死を根治**: accept loop 内の handshake await が失敗すると loop 全体が
+  死ぬ問題を修正。handshake を spawn 済み task 内へ移動し、失敗した handshake が acceptor を
+  殺さないようにした。回帰テスト `acceptor_survives_failed_handshake` 追加。
 
 ## [1.6.0] - 2026-07-11 — connect_race: Happy Eyeballs v2 staggered-race dialer
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A type-safe QUIC communication framework, defined by KDL schema.
 ```toml
 [dependencies]
 # crates.io package = `club-unison`, Rust crate identifier = `unison`
-club-unison = "1.5.0"
+club-unison = "1.7.0"
 tokio = { version = "1.52", features = ["full"] }
 ```
 
@@ -242,7 +242,7 @@ The server stays Rust; clients are first-class siblings under [`clients/`](https
 > (`vX.Y.Z` = Rust workspace 版) に連動する (Swift client は独立 versioning しない)。
 >
 > ```swift
-> .package(url: "https://github.com/chronista-club/club-unison.git", from: "1.5.0")
+> .package(url: "https://github.com/chronista-club/club-unison.git", from: "1.7.0")
 > // target: .product(name: "UnisonClient", package: "club-unison")
 > ```
 >

--- a/docs/kdl-to-json-schema.md
+++ b/docs/kdl-to-json-schema.md
@@ -1,8 +1,8 @@
 # KDL → JSON Schema 対応表
 
-> **Status**: v0.1.0 (Unison Hailing α P3b 一部)
+> **Status**: v0.2.0 (= 1.7.0 で `returns` → `Tool.output_schema` 対応、 converter は入出力両用に)
 > **Implementation**: `crates/unison-mcp/src/mapping.rs::field_type_to_schema`
-> **Consumers**: MCP `Tool.input_schema` / Anthropic Messages API `tools[].input_schema` / OpenAI `response_format` / Vercel AI SDK `generateObject` / Instructor / outlines
+> **Consumers**: MCP `Tool.input_schema` / **MCP `Tool.output_schema`** (= KDL `returns` block) / Anthropic Messages API `tools[].input_schema` / OpenAI `response_format` / Vercel AI SDK `generateObject` / Instructor / outlines
 
 ## 1. なぜこの対応表が要るか
 
@@ -36,9 +36,11 @@ KDL は Unison の SSOT として channel/request/event の型を語る。 こ�
 - KDL field の制約 (= `min`, `max`, `min_length`, `max_length`, `pattern`) — v0.1.0 では schema に出力しない (= constraint 検証は SchemaRegistry 側でも未実装)
 - `Int` の sub-type 区別 (= i32 vs i64) — JSON Schema は integer 1 種類、 範囲は constraint で表現可能
 
-## 3. Request schema 構築 (= 複数 field の組み合わせ)
+## 3. Request / Returns schema 構築 (= 複数 field の組み合わせ)
 
-`fields_to_input_schema(fields: &[Field]) -> JsonObject` の出力:
+`fields_to_object_schema(fields: &[Field]) -> JsonObject` の出力
+(= `request.fields` → `Tool.input_schema`、 `returns.fields` → `Tool.output_schema` の両方に同一関数を適用。
+型対応・required・additionalProperties の挙動が入出力で完全一致する):
 
 ```json
 {
@@ -141,17 +143,21 @@ client.messages.create(
 | `Float` の f32/f64 sub-type 区別 | JSON Schema の `format` 拡張で表現可 (= `float`/`double`) |
 | 制約 (`min`/`max`/`pattern`) の schema 出力 | constraint Epic で SchemaRegistry validation と同時に追加 |
 | `additionalProperties: false` の strict mode | strict-validation opt-in (= 別 channel attribute or call site flag) |
-| 返り値 (`returns`) の schema → MCP `Tool.output_schema` | P3c 以降の polish phase |
 | KDL `description` の channel/request level 集約 | tool description の自動充実 |
+| KDL に MCP hint 属性 (`readonly` / `destructive` / `idempotent`) → `ToolAnnotations` 合成 | 未着手 (= P3 watch、 spec/ 提案候補) |
+
+> `returns` → `Tool.output_schema` は **1.7.0 で実装済み** (= 本表から昇格)。
 
 ## 6. テスト位置
 
 | test | 場所 | 検証内容 |
 |---|---|---|
 | 基本型 → schema 変換 | `mapping.rs` 内 `field_type_*_to_schema` 各 unit test | 個別 FieldType の正しい変換 |
-| Request → input schema 構築 | `mapping.rs` 内 `fields_to_input_schema_basic` | properties + required + additionalProperties |
+| Request → object schema 構築 | `mapping.rs` 内 `fields_to_object_schema_basic` | properties + required + additionalProperties |
+| Returns → output_schema 合成 | `mapping.rs` 内 `synthesize_tool_with_returns_produces_output_schema` ほか | returns 有→schema 宣言 / 無→非宣言 |
+| Untrusted KDL 防御 | `mapping.rs` 内 `fields_to_object_schema_{skips_hostile_field_names,sanitizes_field_description,caps_field_count}` | hostile field 名 skip / desc sanitize / field 数 cap |
 | Anthropic compat | `mapping.rs` 内 `input_schema_is_anthropic_compatible` | top-level type=object + JSON serializable |
-| E2E synthesis | `crates/unison-mcp/tests/test_integ_synthesis.rs` | discovery server → UnisonMcp → list_tools / invoke_tool |
+| E2E synthesis | `crates/unison-mcp/tests/test_integ_synthesis.rs` | discovery server → UnisonMcp → list_tools / invoke_tool / live refresh |
 
 ## 7. 参照
 


### PR DESCRIPTION
## Release 1.7.0

**内容**: #88（rmcp 2.2）/ #89（Edge CI ゲート）/ #90（QUIC accept loop 片肺死修正）/ #91（typed I/O + live re-discovery + elicitation）/ #92（UX 整備 + review fix）

**品質ゲート**: team-b Moody Blues ディープレビュー **SHIP IT**（MEDIUM 2 件 + LOW 1 件は解消済み、詳細は #92 コメント）。unit 45 / E2E 7 / workspace 全 green。

**この PR**:
- CHANGELOG: 漏れていた #90 Fixed / #92 Changed を補完 → `[1.7.0] - 2026-07-14` stamp
- workspace version 1.6.0 → 1.7.0
- README バージョンピン 1.5.0 → 1.7.0（Moody Blues F4）
- `docs/kdl-to-json-schema.md` 同期: returns→output_schema を将来拡張表から実装済みへ昇格、`fields_to_object_schema` rename 反映、テスト表更新

**マージ後**: main を nightly に promote → `v1.7.0` tag → crates.io publish（1.6.0 まで publish 済みの運用に従う）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxnrvNjvkqy3MPhciMJwVh