### PR TITLE
feat(kdl): request に safety hint 属性 readonly/destructive/idempotent を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- **KDL request に safety hint 属性 `readonly` / `destructive` / `idempotent` を追加**:
+  channel 作者が自メソッドの副作用特性を KDL schema で宣言し（例: `request "Query"
+  readonly=#true idempotent=#true { ... }`）、AI agent 等の consumer が尊重する構図。
+  unison-mcp は synthesized tool の `ToolAnnotations`（`readOnlyHint` / `destructiveHint` /
+  `idempotentHint`）へそのまま写し、あわせて全 synthesized tool に `openWorldHint: true` を
+  付与（= bridge は外部 Unison server と対話する、static tools と同方針）。未宣言の hint は
+  set せず MCP client の spec default 解釈に委ねる。`readonly=#true destructive=#true` の
+  同時宣言は矛盾として parse 時に validation error。additive（既存 schema は無改修で従来
+  どおり動作）。spec/02 §4.4 に Request 属性の節を追記（実装先行だった `description` 属性も
+  同時に文書化）。
+
 ## [1.7.0] - 2026-07-14 — unison-mcp: rmcp 2 系 + live MCP bridge 化
 
 > unison-mcp を MCP spec 2025-06-18+ 世代へ引き上げるリリース。KDL `returns` からの

--- a/crates/unison-mcp/src/mapping.rs
+++ b/crates/unison-mcp/src/mapping.rs
@@ -16,7 +16,7 @@
 //!
 //! 全 ecosystem が JSON Schema を共通通貨にしているため、 converter 1 つで全部に届く。
 
-use rmcp::model::{JsonObject, Tool};
+use rmcp::model::{JsonObject, Tool, ToolAnnotations};
 use serde_json::{Map, Value, json};
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -97,6 +97,10 @@ fn sanitize_description(s: &str) -> String {
 /// - input_schema: `request.fields` を JSON Schema object に変換
 /// - output_schema: KDL `returns` block があれば同じ converter で合成
 ///   (= tool が入出力とも typed になり、 client は `structuredContent` を検証できる)
+/// - annotations: `open_world(true)` を base に (= bridge は外部 Unison server と
+///   対話する、 static tools と同方針)、 KDL の safety hint (`readonly` /
+///   `destructive` / `idempotent`) が宣言されていればそれを写す。 未宣言の hint は
+///   set しない (= 「不明」 を MCP client 側の spec default に委ねる)
 ///
 /// description は LLM の tool-selection accuracy に強相関するので、 schema 設計時に
 /// `description="..."` を書くことで LLM が tool を正しく選びやすくなる。
@@ -123,7 +127,17 @@ pub fn synthesize_tool(channel_name: &str, request: &ChannelRequest) -> Tool {
     if let Some(returns) = &request.returns {
         tool = tool.with_raw_output_schema(Arc::new(fields_to_object_schema(&returns.fields)));
     }
-    tool
+    let mut annotations = ToolAnnotations::new().open_world(true);
+    if let Some(readonly) = request.readonly {
+        annotations = annotations.read_only(readonly);
+    }
+    if let Some(destructive) = request.destructive {
+        annotations = annotations.destructive(destructive);
+    }
+    if let Some(idempotent) = request.idempotent {
+        annotations = annotations.idempotent(idempotent);
+    }
+    tool.annotate(annotations)
 }
 
 /// 1 schema あたりの field 数上限 (= 巨大 / 悪意ある KDL による schema 肥大の防御、
@@ -302,6 +316,9 @@ mod tests {
         let req = ChannelRequest {
             name: "Send".to_string(),
             description: Some("evil\x1b[2Jclear".to_string()),
+            readonly: None,
+            destructive: None,
+            idempotent: None,
             fields: vec![],
             returns: None,
         };
@@ -658,6 +675,9 @@ protocol "x" version="0.1.0" {
         let req = ChannelRequest {
             name: "Fire".to_string(),
             description: None,
+            readonly: None,
+            destructive: None,
+            idempotent: None,
             fields: vec![],
             returns: None,
         };
@@ -672,6 +692,9 @@ protocol "x" version="0.1.0" {
         let req = ChannelRequest {
             name: "GetProtocol".to_string(),
             description: None,
+            readonly: None,
+            destructive: None,
+            idempotent: None,
             fields: vec![],
             returns: None,
         };
@@ -679,6 +702,67 @@ protocol "x" version="0.1.0" {
         assert_eq!(tool.title.as_deref(), Some("unison.discovery.GetProtocol"));
         // name 側は従来どおり正規化される
         assert_eq!(tool.name.as_ref(), "unison_unison_discovery_GetProtocol");
+    }
+
+    /// KDL safety hint (`readonly` / `destructive` / `idempotent`) は
+    /// `ToolAnnotations` の対応する hint に写される。
+    #[test]
+    fn synthesize_tool_maps_safety_hints_to_annotations() {
+        let req = ChannelRequest {
+            name: "Query".to_string(),
+            description: None,
+            readonly: Some(true),
+            destructive: None,
+            idempotent: Some(true),
+            fields: vec![],
+            returns: None,
+        };
+        let tool = synthesize_tool("memory", &req);
+        let ann = tool.annotations.as_ref().unwrap();
+        assert_eq!(ann.read_only_hint, Some(true));
+        assert_eq!(ann.idempotent_hint, Some(true));
+        // 未宣言の hint は set しない (= MCP client の spec default に委ねる)
+        assert_eq!(ann.destructive_hint, None);
+        // bridge は外部 Unison server と対話する (= static tools と同方針)
+        assert_eq!(ann.open_world_hint, Some(true));
+    }
+
+    /// destructive=#false の明示宣言 (= 「非破壊」 の積極表明) も写される。
+    #[test]
+    fn synthesize_tool_maps_explicit_destructive_false() {
+        let req = ChannelRequest {
+            name: "Upsert".to_string(),
+            description: None,
+            readonly: None,
+            destructive: Some(false),
+            idempotent: None,
+            fields: vec![],
+            returns: None,
+        };
+        let tool = synthesize_tool("memory", &req);
+        let ann = tool.annotations.as_ref().unwrap();
+        assert_eq!(ann.destructive_hint, Some(false));
+        assert_eq!(ann.read_only_hint, None);
+    }
+
+    /// hint 未宣言の request は open_world 以外の hint を持たない。
+    #[test]
+    fn synthesize_tool_without_hints_leaves_hints_unset() {
+        let req = ChannelRequest {
+            name: "Send".to_string(),
+            description: None,
+            readonly: None,
+            destructive: None,
+            idempotent: None,
+            fields: vec![],
+            returns: None,
+        };
+        let tool = synthesize_tool("chat", &req);
+        let ann = tool.annotations.as_ref().unwrap();
+        assert_eq!(ann.read_only_hint, None);
+        assert_eq!(ann.destructive_hint, None);
+        assert_eq!(ann.idempotent_hint, None);
+        assert_eq!(ann.open_world_hint, Some(true));
     }
 
     /// Anthropic Messages API `tools[].input_schema` 互換性: top-level に

--- a/crates/unison-protocol/src/parser/schema.rs
+++ b/crates/unison-protocol/src/parser/schema.rs
@@ -119,6 +119,27 @@ pub struct ChannelRequest {
     #[kdl(property)]
     pub description: Option<String>,
 
+    /// 環境を変更しない読み取り専用リクエストであることの宣言 (= safety hint)。
+    ///
+    /// optional。 server 作者が自チャネルの安全性を宣言し、 AI agent 等の
+    /// consumer (= unison-mcp の `ToolAnnotations` 合成など) が尊重する。
+    /// 未宣言 (= `None`) は「不明」であり consumer 側の default に委ねる。
+    /// `destructive=#true` との同時宣言は矛盾として validation error。
+    #[kdl(property)]
+    pub readonly: Option<bool>,
+
+    /// 破壊的更新 (= 復元不能な削除・上書き) があり得ることの宣言 (= safety hint)。
+    ///
+    /// optional。 semantics は [`Self::readonly`] と同じ hint 系。
+    #[kdl(property)]
+    pub destructive: Option<bool>,
+
+    /// 同一引数での再実行が追加の効果を持たないことの宣言 (= safety hint)。
+    ///
+    /// optional。 semantics は [`Self::readonly`] と同じ hint 系。
+    #[kdl(property)]
+    pub idempotent: Option<bool>,
+
     /// リクエストフィールド
     #[kdl(children, name = "field")]
     pub fields: Vec<Field>,
@@ -194,7 +215,17 @@ impl Channel {
     /// - `backend="datagram"` の場合は `channel_id` が必須、 0 は予約 (= sentinel)
     /// - `backend="stream"` (= default) の場合は `channel_id` を指定しても無視 (= warning は出さない)
     /// - `backend="datagram"` の channel は `request` ブロックを持てない (= datagram は応答不可)
+    /// - request の safety hint は `readonly=#true` と `destructive=#true` を同時宣言できない (= 矛盾)
     pub fn validate(&self) -> Result<(), String> {
+        for request in &self.requests {
+            if request.readonly == Some(true) && request.destructive == Some(true) {
+                return Err(format!(
+                    "request \"{}\" in channel \"{}\" declares both readonly=#true and \
+                     destructive=#true; a readonly request cannot be destructive — pick one",
+                    request.name, self.name
+                ));
+            }
+        }
         match self.backend() {
             ChannelBackend::Datagram => {
                 let id = self.channel_id.ok_or_else(|| {

--- a/crates/unison-protocol/tests/test_kdl.rs
+++ b/crates/unison-protocol/tests/test_kdl.rs
@@ -336,3 +336,80 @@ fn test_channel_mixed_stream_and_datagram_channels() {
     assert_eq!(protocol.channels[2].backend(), ChannelBackend::Datagram);
     assert_eq!(protocol.channels[2].channel_id, Some(2));
 }
+
+/// request の safety hint (`readonly` / `destructive` / `idempotent`) がパースされる
+#[test]
+fn test_request_safety_hints_parsed() {
+    let schema = r#"
+        protocol "test" version="1.0.0" {
+            channel "memory" from="client" lifetime="persistent" {
+                request "Query" readonly=#true idempotent=#true {
+                    field "key" type="string"
+                    returns "Result" { field "value" type="json" }
+                }
+                request "Delete" destructive=#true {
+                    field "key" type="string"
+                    returns "Deleted" { field "ok" type="bool" }
+                }
+            }
+        }
+    "#;
+    let parser = SchemaParser::new();
+    let protocol = parser.parse(schema).unwrap().protocol.unwrap();
+    let ch = &protocol.channels[0];
+
+    let query = &ch.requests[0];
+    assert_eq!(query.readonly, Some(true));
+    assert_eq!(query.idempotent, Some(true));
+    assert_eq!(query.destructive, None);
+
+    let delete = &ch.requests[1];
+    assert_eq!(delete.destructive, Some(true));
+    assert_eq!(delete.readonly, None);
+    assert_eq!(delete.idempotent, None);
+}
+
+/// safety hint 未宣言の request は全 hint が None (= 従来 schema 互換)
+#[test]
+fn test_request_without_safety_hints_defaults_to_none() {
+    let schema = r#"
+        protocol "test" version="1.0.0" {
+            channel "chat" from="client" lifetime="persistent" {
+                request "Send" {
+                    field "text" type="string"
+                    returns "Sent" { field "ok" type="bool" }
+                }
+            }
+        }
+    "#;
+    let parser = SchemaParser::new();
+    let protocol = parser.parse(schema).unwrap().protocol.unwrap();
+    let req = &protocol.channels[0].requests[0];
+    assert_eq!(req.readonly, None);
+    assert_eq!(req.destructive, None);
+    assert_eq!(req.idempotent, None);
+}
+
+/// `readonly=#true` と `destructive=#true` の同時宣言は矛盾 → validation error
+#[test]
+fn test_request_readonly_and_destructive_conflict_fails() {
+    let schema = r#"
+        protocol "test" version="1.0.0" {
+            channel "memory" from="client" lifetime="persistent" {
+                request "Broken" readonly=#true destructive=#true {
+                    field "key" type="string"
+                }
+            }
+        }
+    "#;
+    let parser = SchemaParser::new();
+    let err = parser
+        .parse(schema)
+        .expect_err("readonly + destructive must fail validation");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("readonly") && msg.contains("destructive"),
+        "error must mention the conflicting hints: {}",
+        msg
+    );
+}

--- a/spec/02-unified-channel/SPEC.md
+++ b/spec/02-unified-channel/SPEC.md
@@ -1,8 +1,8 @@
 # spec/02: Unison Protocol - Unified Channel プロトコル仕様
 
-**バージョン**: 2.1.0-draft (v0.10.0 で `backend` / `channel_id` 属性追加)
-**最終更新**: 2026-05-15
-**ステータス**: Stable (v0.9.0 で 2.0.0 確定)、 v0.10.0 で datagram channel narrative を additive 拡張中
+**バージョン**: 2.2.0-draft (request の `description` / safety hint 属性 `readonly` `destructive` `idempotent` を追記)
+**最終更新**: 2026-07-14
+**ステータス**: Stable (v0.9.0 で 2.0.0 確定)、 additive 拡張中 (v0.10.0 datagram channel / request 属性)
 
 ---
 
@@ -194,6 +194,37 @@ channel "<name>" from="<direction>" lifetime="<lifetime>" {
 - **1 channel = 1 (virtual) stream**: stream channel は QUIC bidi stream に直接対応、 datagram channel は connection 内の共有 datagram path 上に `channel_id` で識別される **virtual stream** として存在。
 - **1 channel = 1 backend (strict)**: 1 channel block 内の event は全て同じ backend に従う。 stream/datagram event の mixed channel は v0.10.0 では disallow (= forward-compatible、 将来許容化可)。
 - **互換性**: `backend` 属性なしの v0.9.0 schema は default `"stream"` 解釈で動作、 v0.9.0 caller は無改修。
+
+#### Request 属性
+
+`request` ノードには optional 属性を付与できる:
+
+| 属性 | 値 | 説明 |
+|------|-----|------|
+| `description` | string | リクエストの人間可読な説明。unison-mcp の MCP tool description 等、AI agent が読む説明文に流れる |
+| `readonly` | `#true` / `#false` | 環境を変更しない読み取り専用リクエストであることの宣言 (= safety hint) |
+| `destructive` | `#true` / `#false` | 破壊的更新（復元不能な削除・上書き）があり得ることの宣言。`#false` は「追加のみ」の積極表明 (= safety hint) |
+| `idempotent` | `#true` / `#false` | 同一引数での再実行が追加の効果を持たないことの宣言 (= safety hint) |
+
+**Safety hints** (`readonly` / `destructive` / `idempotent`) は、channel 作者が自メソッドの副作用特性を宣言し、AI agent 等の consumer がそれを尊重するための仕組み:
+
+- **宣言は optional** — 未宣言は「不明」であり、consumer 側の default 解釈に委ねる。KDL parser は未宣言を `None` として保持し、default 値へ潰さない
+- **hint であって enforcement ではない** — protocol runtime は宣言と実際の挙動の一致を検証しない。宣言の信頼性は server 作者への信頼と同一（= untrusted server の hint を security 判断に使わない）
+- **矛盾は validation error** — `readonly=#true destructive=#true` の同時宣言は parse 時に拒否される
+- **MCP への写像** — unison-mcp bridge は synthesized tool の `ToolAnnotations`（`readOnlyHint` / `destructiveHint` / `idempotentHint`）へそのまま写す。未宣言 hint は MCP spec の default（readOnly=false / destructive=true / idempotent=false）解釈に委ねられる
+
+```kdl
+channel "memory" from="client" lifetime="persistent" {
+    request "Query" readonly=#true idempotent=#true {
+        field "key" type="string"
+        returns "Result" { field "value" type="json" }
+    }
+    request "Delete" destructive=#true {
+        field "key" type="string"
+        returns "Deleted" { field "ok" type="bool" }
+    }
+}
+```
 
 #### メッセージブロック
 
@@ -643,6 +674,6 @@ v0.10.0 でも残存 (= channel API の制約に当てはまらない caller の
 
 ---
 
-**仕様バージョン**: 2.0.0-draft
-**最終更新**: 2026-02-16
+**仕様バージョン**: 2.2.0-draft
+**最終更新**: 2026-07-14
 **ステータス**: Draft


### PR DESCRIPTION
## 概要

KDL schema の `request` ノードに **safety hint 属性**（`readonly` / `destructive` / `idempotent`）を追加し、unison-mcp の synthesized tool の `ToolAnnotations` へ合成する。

channel 作者が自メソッドの副作用特性を宣言し、AI agent 等の consumer がそれを尊重する構図（rmcp 2.x 残余アイデアのウォッチリスト item 3 の実現、PR #91 調査時の還元候補）。

```kdl
channel "memory" from="client" lifetime="persistent" {
    request "Query" readonly=#true idempotent=#true {
        field "key" type="string"
        returns "Result" { field "value" type="json" }
    }
    request "Delete" destructive=#true {
        field "key" type="string"
        returns "Deleted" { field "ok" type="bool" }
    }
}
```

## 変更内容

### unison-protocol（parser）
- `ChannelRequest` に `Option<bool>` の `readonly` / `destructive` / `idempotent` を追加
- 未宣言は `None` として保持（consumer 側の default 解釈に委ねる — hint を default 値へ潰さない）
- `Channel::validate()` に矛盾チェック追加: `readonly=#true destructive=#true` の同時宣言は parse 時に validation error

### unison-mcp（合成）
- `synthesize_tool()` が hint を `ToolAnnotations`（`readOnlyHint` / `destructiveHint` / `idempotentHint`）へ写す
- あわせて全 synthesized tool に `openWorldHint: true` を付与（= bridge は外部 Unison server と対話する、static tools と同方針。MCP spec default と同値なので挙動不変）
- 未宣言の hint は set しない（MCP client の spec default: readOnly=false / destructive=true / idempotent=false）

### spec / docs
- spec/02 §4.4 に「Request 属性」の節を新設（実装先行で spec 未記載だった `description` 属性も同時に文書化）
- hint は enforcement ではない旨を明記（untrusted server の hint を security 判断に使わない）
- CHANGELOG [Unreleased] にエントリ追加

## 互換性

additive — 既存 schema は無改修で従来どおり動作。既存 synthesized tool の annotations は `openWorldHint: true` が明示されるのみ（spec default と同値）。

## テスト

- `test_kdl.rs` +3: hint パース / 未宣言 None / 矛盾 validation error — **15 passed**
- `mapping.rs` +3: hint → annotations 写像 / `destructive=#false` 明示 / 未宣言 unset — **unison-mcp lib 48 passed**
- `cargo test --workspace` 全 suite green / `cargo clippy --lib --workspace -- -D warnings` clean

※ `cargo clippy --tests` はローカル clippy 1.96 の新 lint `while_let_loop` が **本 PR と無関係の既存コード**（`test_medium_datagram_echo.rs` / `unison-cli`）に発火する。CI stable では発火しない（1.7.0 が green）ため本 PR の scope 外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)