### PR TITLE
chore(release): 1.8.0 — KDL request safety hint 属性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-07-15 — KDL request safety hint 属性
+
+> channel 作者が自メソッドの副作用特性（read-only / destructive / idempotent）を KDL schema で
+> 宣言し、unison-mcp が MCP `ToolAnnotations` へ写して AI agent が尊重できるようにするリリース
+> （#94）。1.7.0 の unison-mcp typed I/O + live bridge 化に続く、KDL → MCP hint パイプラインの
+> 拡充。SemVer minor（additive、既存 schema / API は無改修）。
+
 ### Added
 
 - **KDL request に safety hint 属性 `readonly` / `destructive` / `idempotent` を追加**:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 authors = ["Mako<mito@chronista.club>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A type-safe QUIC communication framework, defined by KDL schema.
 ```toml
 [dependencies]
 # crates.io package = `club-unison`, Rust crate identifier = `unison`
-club-unison = "1.7.0"
+club-unison = "1.8.0"
 tokio = { version = "1.52", features = ["full"] }
 ```
 
@@ -242,7 +242,7 @@ The server stays Rust; clients are first-class siblings under [`clients/`](https
 > (`vX.Y.Z` = Rust workspace 版) に連動する (Swift client は独立 versioning しない)。
 >
 > ```swift
-> .package(url: "https://github.com/chronista-club/club-unison.git", from: "1.7.0")
+> .package(url: "https://github.com/chronista-club/club-unison.git", from: "1.8.0")
 > // target: .product(name: "UnisonClient", package: "club-unison")
 > ```
 >


### PR DESCRIPTION
## 概要

#94（KDL request safety hint 属性）のリリース。version bump + CHANGELOG stamp + README ピン更新。

KDL request の safety hint（`readonly` / `destructive` / `idempotent`）を unison-mcp の `ToolAnnotations` へ写す **KDL → MCP hint パイプライン**の拡充。1.7.0 の unison-mcp typed I/O + live bridge 化に続く。

**SemVer minor**（additive、既存 schema / API は無改修で従来どおり動作）。

## 変更内容

- **CHANGELOG**: `[Unreleased]` → `[1.8.0]` stamp + release narrative 追加
- **workspace version**: 1.7.0 → 1.8.0（`Cargo.toml`）
- **README**: バージョンピン 1.7.0 → 1.8.0（Cargo dependency + SwiftPM `.package(from:)` 両方）

## 同梱 PR

- #94 — feat(kdl): request に safety hint 属性 readonly/destructive/idempotent を追加

## 検証

- `cargo build --workspace` green（1.8.0 で全 crate コンパイル確認）
- #94 マージ時点で `cargo test --workspace` 全 suite green / `clippy --lib` clean 済
- コード変更なし（version メタデータ + doc のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)