### PR TITLE
fix(swift): zstd 圧縮 packet の受信展開を実装

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,12 +27,18 @@ let package = Package(
     dependencies: [
         // wire format = protocol.proto → swift-protobuf 生成 (Apple 公式)。
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.38.0"),
+        // zstd 展開 (facebook 公式が SPM 対応)。 Rust server は 2KB 以上の payload を
+        // 自動で zstd 圧縮する (packet/mod.rs) — 受信側の展開が無いと大きな
+        // response / event が読めない (実測 2026-08-15: fieldd の 64-entity 応答)。
+        // Apple Compression framework は zstd 非対応のため公式 C 実装を使う。
+        .package(url: "https://github.com/facebook/zstd.git", from: "1.5.7"),
     ],
     targets: [
         .target(
             name: "UnisonClient",
             dependencies: [
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+                .product(name: "libzstd", package: "zstd"),
             ],
             // source 実体は monorepo の clients/swift/ 配下 (root manifest から path 参照)。
             path: "clients/swift/Sources/UnisonClient"

--- a/clients/swift/Sources/UnisonClient/Wire/Packet.swift
+++ b/clients/swift/Sources/UnisonClient/Wire/Packet.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftProtobuf
+import libzstd
 
 /// `UnisonPacket` wire layer。 Rust `crates/unison-protocol/src/packet/` の
 /// `[u32 BE header_len][PacketHeader][payload]` と byte 一致する。
@@ -9,7 +10,11 @@ import SwiftProtobuf
 /// ```
 ///
 /// `payload` は encode 済み `ProtocolMessage` バイト列。 TS client と同様、 常に
-/// 非圧縮で送る (`compressed_length = 0`)。 圧縮 packet 受信時は明示 error。
+/// 非圧縮で送る (`compressed_length = 0`)。 **受信は zstd 展開に対応する** —
+/// Rust server は 2KB 以上の payload を自動圧縮する (packet/mod.rs) ため、
+/// 展開が無いと大きな response / event が読めない (実測 2026-08-15:
+/// fieldd の 64-entity FieldSnapshot で発覚 — 小さい open_ack は届くのに
+/// 大きな応答だけ落ちる、という一番分かりにくい形で現れる)。
 enum Packet {
     /// PacketHeader に乗せる任意設定 (= 全 field 既定、 caller が必要分のみ上書き)。
     struct Options {
@@ -85,12 +90,42 @@ enum Packet {
                 "packet: payload size \(payload.count) != header 宣言 \(expected)"
             )
         }
-        if header.compressedLength > 0 && (header.flags & 0x0001) != 0 {
-            throw UnisonError.codec(
-                "packet: zstd 圧縮 payload は未対応 (= fixture は < 2KB / 非圧縮)"
-            )
+        if header.compressedLength > 0 {
+            // flag bit 0 = zstd (Rust `PacketFlags::is_compressed`)。 立っていない
+            // のに compressed_length > 0 は仕様外 — 黙って生バイトを返すと
+            // decode 失敗が下流に化けるので、ここで名指しで落とす
+            guard (header.flags & 0x0001) != 0 else {
+                throw UnisonError.codec(
+                    "packet: compressed_length > 0 なのに zstd flag が無い (flags=\(header.flags))"
+                )
+            }
+            return Decoded(
+                header: header,
+                payload: try decompress(payload, expectedSize: Int(header.payloadLength)))
         }
         return Decoded(header: header, payload: payload)
+    }
+
+    /// zstd 展開 (= Rust `zstd::decode_all` の対向)。 payload_length が展開後
+    /// サイズの宣言なので、 ぴったりのバッファ 1 回で済む
+    private static func decompress(_ compressed: Data, expectedSize: Int) throws -> Data {
+        guard expectedSize > 0 else {
+            throw UnisonError.codec("packet: zstd 展開後サイズの宣言が 0")
+        }
+        var output = Data(count: expectedSize)
+        let written = output.withUnsafeMutableBytes { dst in
+            compressed.withUnsafeBytes { src in
+                ZSTD_decompress(
+                    dst.baseAddress, expectedSize,
+                    src.baseAddress, compressed.count)
+            }
+        }
+        guard ZSTD_isError(written) == 0, written == expectedSize else {
+            throw UnisonError.codec(
+                "packet: zstd 展開失敗 (宣言 \(expectedSize) bytes, 結果 \(written))"
+            )
+        }
+        return output
     }
 }
 

--- a/clients/swift/Tests/UnisonClientTests/LiveE2ETests.swift
+++ b/clients/swift/Tests/UnisonClientTests/LiveE2ETests.swift
@@ -40,3 +40,37 @@ struct LiveE2ETests {
         await conn.disconnect()
     }
 }
+
+// fieldd (bikeboy-ladyland/field) 相手の再現テスト — 2026-08-15 実機で
+// 「openChannel は通るのに Join の応答だけ 3s timeout」の根治用。
+//   1) bikeboy-ladyland/field で cargo run（[::]:7879）
+//   2) FIELD_LIVE=1 swift test --filter FieldLive
+
+private struct PresenceMeta: StreamChannelMeta {
+    static let name = "presence"
+    struct FieldTick: Codable, Sendable {}
+    typealias Event = FieldTick
+}
+
+private struct FieldJoin: UnisonRequest {
+    static let method = "Join"
+    struct Snapshot: Codable, Sendable {}
+    typealias Response = Snapshot
+    let role: String
+}
+
+struct FieldLiveTests {
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["FIELD_LIVE"] == "1"
+    }
+
+    /// 最小再現: 単発の Join round-trip（Ladyland ではここで 3s timeout した）
+    @Test(.enabled(if: FieldLiveTests.enabled))
+    func fieldJoinRoundTrip() async throws {
+        let conn = try await UnisonClient.connect(to: .localDaemon(port: 7879), trust: .skipVerify)
+        let channel = try await conn.openChannel(PresenceMeta())
+        _ = try await channel.request(FieldJoin(role: "probe-swift"))
+        await channel.close()
+        await conn.disconnect()
+    }
+}

--- a/clients/swift/Tests/UnisonClientTests/WireByteCompatTests.swift
+++ b/clients/swift/Tests/UnisonClientTests/WireByteCompatTests.swift
@@ -142,3 +142,56 @@ extension Data {
         map { String(format: "%02x", $0) }.joined()
     }
 }
+
+// zstd 展開 (2026-08-15)。 Rust server は 2KB 以上の payload を自動圧縮する —
+// 自己圧縮 fixture で decode round-trip を固定する (libzstd は依存済みなので
+// テストからも直接使える)。
+import libzstd
+
+struct PacketZstdTests {
+    /// 圧縮 packet (flag bit 0 + compressed_length) が展開されて返る
+    @Test func decodesZstdCompressedPayload() throws {
+        // 圧縮が効く冗長データ (JSON 想定に寄せた繰り返し)
+        let original = Data(String(repeating: #"{"id":1,"level":0.5}"#, count: 300).utf8)
+        let bound = ZSTD_compressBound(original.count)
+        var compressed = Data(count: bound)
+        let written = compressed.withUnsafeMutableBytes { dst in
+            original.withUnsafeBytes { src in
+                ZSTD_compress(dst.baseAddress, bound, src.baseAddress, original.count, 3)
+            }
+        }
+        try #require(ZSTD_isError(written) == 0)
+        compressed.removeSubrange(written..<compressed.count)
+
+        var header = Protocol_PacketHeader()
+        header.version = 1
+        header.payloadLength = UInt32(original.count)
+        header.compressedLength = UInt32(compressed.count)
+        header.flags = 0x0001  // zstd (Rust PacketFlags::is_compressed)
+        let headerBytes = try header.serializedData()
+        var packet = Data()
+        packet.appendBigEndian(UInt32(headerBytes.count))
+        packet.append(headerBytes)
+        packet.append(compressed)
+
+        let decoded = try Packet.decode(packet)
+        #expect(decoded.payload == original)
+        #expect(decoded.header.payloadLength == UInt32(original.count))
+    }
+
+    /// compressed_length > 0 なのに zstd flag が無い packet は名指しで落ちる
+    @Test func rejectsCompressedLengthWithoutFlag() throws {
+        var header = Protocol_PacketHeader()
+        header.version = 1
+        header.payloadLength = 10
+        header.compressedLength = 4
+        header.flags = 0
+        let headerBytes = try header.serializedData()
+        var packet = Data()
+        packet.appendBigEndian(UInt32(headerBytes.count))
+        packet.append(headerBytes)
+        packet.append(Data([1, 2, 3, 4]))
+
+        #expect(throws: UnisonError.self) { _ = try Packet.decode(packet) }
+    }
+}


### PR DESCRIPTION
## 症状

Rust server は 2KB 以上の payload を自動で zstd 圧縮する（`packet/mod.rs` 仕様）が、Swift client は圧縮 packet を明示 error にしていた（既知の未実装）。**小さい open_ack は届くのに、大きな response / event だけ落ちる**という一番分かりにくい形で現れる。

実測（2026-08-15、bikeboy-ladyland の fieldd）: 64-entity の FieldSnapshot 応答（~6KB）が 3s timeout。Rust client（unison-mcp）は同じ応答を完食するので、切り分けに時間を要した。

## 修正

- facebook/zstd 公式（SPM 対応）を依存に追加し、受信側の展開を実装（Apple の Compression framework は zstd 非対応）
- `compressed_length > 0` なのに zstd flag が無い packet は名指しで reject（黙って生バイトを返すと下流で decode 失敗に化ける）

## テスト

- `PacketZstdTests`: 自己圧縮 round-trip + flag 検証（ユニット、CI で回る）
- `FieldLiveTests`: `FIELD_LIVE=1` gate の live interop（fieldd 相手 — LiveE2ETests と同じ作法）
- 全ユニット 24 本 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)